### PR TITLE
feat: support multiple availability schedules per event type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,14 +36,14 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@types/uuid": "^10.0.0",
-        "@vitejs/plugin-react": "^5.1.4",
+        "@vitejs/plugin-react": "^5.2.0",
         "eslint": "^8",
         "eslint-config-next": "14.2.35",
         "postcss": "^8",
         "prisma": "^5.22.0",
         "tailwindcss": "^3.4.1",
         "typescript": "^5",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2546,9 +2546,9 @@
       ]
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
-      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2563,21 +2563,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -2585,13 +2585,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.0",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2600,7 +2600,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2612,9 +2612,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2625,13 +2625,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.0",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2639,13 +2639,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2654,9 +2655,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2664,13 +2665,14 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -3782,9 +3784,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7541,9 +7543,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8061,9 +8063,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8518,31 +8520,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8558,12 +8560,13 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -8592,6 +8595,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/uuid": "^10.0.0",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react": "^5.2.0",
     "eslint": "^8",
     "eslint-config-next": "14.2.35",
     "postcss": "^8",
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "description": "This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).",
   "main": "index.js",

--- a/prisma/migrations/20260313000000_add_availability_schedules/migration.sql
+++ b/prisma/migrations/20260313000000_add_availability_schedules/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "AvailabilitySchedule" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AvailabilitySchedule_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable: add scheduleId to Availability
+ALTER TABLE "Availability" ADD COLUMN "scheduleId" TEXT;
+
+-- AlterTable: add availabilityScheduleId to EventType
+ALTER TABLE "EventType" ADD COLUMN "availabilityScheduleId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AvailabilitySchedule_userId_name_key" ON "AvailabilitySchedule"("userId", "name");
+
+-- AddForeignKey
+ALTER TABLE "AvailabilitySchedule" ADD CONSTRAINT "AvailabilitySchedule_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Availability" ADD CONSTRAINT "Availability_scheduleId_fkey" FOREIGN KEY ("scheduleId") REFERENCES "AvailabilitySchedule"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EventType" ADD CONSTRAINT "EventType_availabilityScheduleId_fkey" FOREIGN KEY ("availabilityScheduleId") REFERENCES "AvailabilitySchedule"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,13 +33,14 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  eventTypes     EventType[]
-  bookings       Booking[]
-  availability   Availability[]
-  calendarConnections CalendarConnection[]
-  webhooks       Webhook[]
-  contacts       Contact[]
-  documents      Document[]
+  eventTypes            EventType[]
+  bookings              Booking[]
+  availability          Availability[]
+  availabilitySchedules AvailabilitySchedule[]
+  calendarConnections   CalendarConnection[]
+  webhooks              Webhook[]
+  contacts              Contact[]
+  documents             Document[]
 }
 
 enum Plan {
@@ -77,6 +78,10 @@ model EventType {
   // Collective scheduling
   isCollective   Boolean @default(false)
   collectiveMembers String[] // user IDs
+
+  // Availability schedule
+  availabilityScheduleId String?
+  availabilitySchedule   AvailabilitySchedule? @relation(fields: [availabilityScheduleId], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -175,11 +180,30 @@ enum BookingStatus {
   NO_SHOW
 }
 
+// ─── Availability Schedules ───
+
+model AvailabilitySchedule {
+  id        String   @id @default(cuid())
+  userId    String
+  name      String
+  isDefault Boolean  @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user       User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rules      Availability[]
+  eventTypes EventType[]
+
+  @@unique([userId, name])
+}
+
 // ─── Availability ───
 
 model Availability {
-  id     String @id @default(cuid())
-  userId String
+  id         String  @id @default(cuid())
+  userId     String
+  scheduleId String?
   
   // Day of week (0=Sunday, 6=Saturday) or specific date
   dayOfWeek Int?      // 0-6
@@ -189,7 +213,8 @@ model Availability {
   endTime   String // "17:00"
   enabled   Boolean @default(true)
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user     User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  schedule AvailabilitySchedule? @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
 }
 
 // ─── Calendar Connections ───

--- a/src/__tests__/integration/multi-calendar-booking.test.ts
+++ b/src/__tests__/integration/multi-calendar-booking.test.ts
@@ -16,6 +16,7 @@ const mockCalendarConnectionCreate = vi.fn()
 const mockUserFindUnique = vi.fn()
 const mockEventTypeFindUnique = vi.fn()
 const mockAvailabilityFindMany = vi.fn()
+const mockAvailabilityScheduleFindFirst = vi.fn()
 const mockBookingFindMany = vi.fn()
 
 vi.mock("@/lib/prisma", () => ({
@@ -38,6 +39,9 @@ vi.mock("@/lib/prisma", () => ({
     },
     availability: {
       findMany: (...args: any[]) => mockAvailabilityFindMany(...args),
+    },
+    availabilitySchedule: {
+      findFirst: (...args: any[]) => mockAvailabilityScheduleFindFirst(...args),
     },
     booking: {
       findMany: (...args: any[]) => mockBookingFindMany(...args),
@@ -106,6 +110,7 @@ function makeTestEventType(overrides = {}) {
     weeklyLimit: null,
     location: "GOOGLE_MEET",
     active: true,
+    availabilityScheduleId: null, // use legacy rules in these tests
     ...overrides,
   }
 }
@@ -159,6 +164,8 @@ describe("Multi-Calendar Booking Flow - Integration Tests", () => {
     vi.clearAllMocks()
     clearEventCache()
     global.fetch = vi.fn()
+    // Default: no named availability schedule → fall back to legacy rules
+    mockAvailabilityScheduleFindFirst.mockResolvedValue(null)
   })
 
   afterEach(() => {

--- a/src/__tests__/integration/multiple-availability-schedules.test.ts
+++ b/src/__tests__/integration/multiple-availability-schedules.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { getAvailableSlots } from "@/lib/availability"
+
+// ─── Mock Prisma ───
+
+const mockUserFindUnique = vi.fn()
+const mockEventTypeFindUnique = vi.fn()
+const mockAvailabilityFindMany = vi.fn()
+const mockAvailabilityScheduleFindFirst = vi.fn()
+const mockBookingFindMany = vi.fn()
+const mockCalendarConnectionFindMany = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: { findUnique: (...args: any[]) => mockUserFindUnique(...args) },
+    eventType: { findUnique: (...args: any[]) => mockEventTypeFindUnique(...args) },
+    availability: { findMany: (...args: any[]) => mockAvailabilityFindMany(...args) },
+    availabilitySchedule: { findFirst: (...args: any[]) => mockAvailabilityScheduleFindFirst(...args) },
+    booking: { findMany: (...args: any[]) => mockBookingFindMany(...args) },
+    calendarConnection: { findMany: (...args: any[]) => mockCalendarConnectionFindMany(...args) },
+  },
+}))
+
+vi.mock("@/lib/calendar/conflict-detection", () => ({
+  getConflictingEvents: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }))
+vi.mock("@/lib/auth", () => ({ getAuthenticatedUser: vi.fn() }))
+
+// ─── Test Data ───
+
+const USER_ID = "user-avail-test"
+const EVENT_TYPE_ID = "et-avail-test"
+const SCHEDULE_A_ID = "schedule-a"
+const SCHEDULE_B_ID = "schedule-b"
+
+// Far future dates to bypass minNotice
+const START = new Date("2027-03-01T00:00:00Z")
+const END = new Date("2027-03-02T00:00:00Z")
+
+function makeUser() {
+  return { id: USER_ID, timezone: "UTC", plan: "PRO" }
+}
+
+function makeEventType(overrides: any = {}) {
+  return {
+    id: EVENT_TYPE_ID,
+    userId: USER_ID,
+    duration: 30,
+    bufferBefore: 0,
+    bufferAfter: 0,
+    minNotice: 0,
+    maxFutureDays: 365,
+    dailyLimit: null,
+    weeklyLimit: null,
+    availabilityScheduleId: null,
+    isCollective: false,
+    ...overrides,
+  }
+}
+
+function makeRules(scheduleId: string | null, startTime = "09:00", endTime = "17:00") {
+  // All days to avoid timezone day-of-week mismatches
+  return Array.from({ length: 7 }, (_, i) => ({
+    id: `rule-${scheduleId}-${i}`,
+    userId: USER_ID,
+    scheduleId,
+    dayOfWeek: i,
+    date: null,
+    startTime,
+    endTime,
+    enabled: true,
+  }))
+}
+
+// ─── Tests ───
+
+describe("Multiple Availability Schedules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockBookingFindMany.mockResolvedValue([])
+    mockCalendarConnectionFindMany.mockResolvedValue([])
+  })
+
+  describe("getAvailableSlots — schedule resolution", () => {
+    it("uses the event type's linked schedule when availabilityScheduleId is set", async () => {
+      mockUserFindUnique.mockResolvedValue(makeUser())
+      mockEventTypeFindUnique.mockResolvedValue(
+        makeEventType({ availabilityScheduleId: SCHEDULE_A_ID })
+      )
+
+      // Schedule A: 10:00–12:00 only (narrow window)
+      mockAvailabilityFindMany.mockResolvedValue(makeRules(SCHEDULE_A_ID, "10:00", "12:00"))
+
+      const slots = await getAvailableSlots({
+        userId: USER_ID,
+        eventTypeId: EVENT_TYPE_ID,
+        startDate: START,
+        endDate: END,
+        timezone: "UTC",
+      })
+
+      // Should only have slots within 10:00–12:00 (30-min events at 15-min increments)
+      expect(slots.length).toBeGreaterThan(0)
+      for (const slot of slots) {
+        const hour = slot.start.getUTCHours()
+        expect(hour).toBeGreaterThanOrEqual(10)
+        expect(hour).toBeLessThan(12)
+      }
+
+      // Prisma was queried with scheduleId = SCHEDULE_A_ID
+      expect(mockAvailabilityFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ scheduleId: SCHEDULE_A_ID }),
+        })
+      )
+      // Default schedule lookup should NOT have been called
+      expect(mockAvailabilityScheduleFindFirst).not.toHaveBeenCalled()
+    })
+
+    it("falls back to the default schedule when event type has no linked schedule", async () => {
+      mockUserFindUnique.mockResolvedValue(makeUser())
+      mockEventTypeFindUnique.mockResolvedValue(makeEventType()) // no availabilityScheduleId
+
+      // Default schedule exists
+      mockAvailabilityScheduleFindFirst.mockResolvedValue({
+        id: SCHEDULE_B_ID,
+        userId: USER_ID,
+        name: "Default",
+        isDefault: true,
+      })
+
+      // Default schedule rules: 14:00–16:00
+      mockAvailabilityFindMany.mockResolvedValue(makeRules(SCHEDULE_B_ID, "14:00", "16:00"))
+
+      const slots = await getAvailableSlots({
+        userId: USER_ID,
+        eventTypeId: EVENT_TYPE_ID,
+        startDate: START,
+        endDate: END,
+        timezone: "UTC",
+      })
+
+      expect(slots.length).toBeGreaterThan(0)
+      for (const slot of slots) {
+        const hour = slot.start.getUTCHours()
+        expect(hour).toBeGreaterThanOrEqual(14)
+        expect(hour).toBeLessThan(16)
+      }
+
+      expect(mockAvailabilityScheduleFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ isDefault: true }) })
+      )
+    })
+
+    it("falls back to legacy unscoped rules when no schedule exists at all", async () => {
+      mockUserFindUnique.mockResolvedValue(makeUser())
+      mockEventTypeFindUnique.mockResolvedValue(makeEventType()) // no availabilityScheduleId
+
+      // No default schedule
+      mockAvailabilityScheduleFindFirst.mockResolvedValue(null)
+
+      // Legacy rules (scheduleId = null): 08:00–10:00
+      mockAvailabilityFindMany.mockResolvedValue(makeRules(null, "08:00", "10:00"))
+
+      const slots = await getAvailableSlots({
+        userId: USER_ID,
+        eventTypeId: EVENT_TYPE_ID,
+        startDate: START,
+        endDate: END,
+        timezone: "UTC",
+      })
+
+      expect(slots.length).toBeGreaterThan(0)
+      for (const slot of slots) {
+        const hour = slot.start.getUTCHours()
+        expect(hour).toBeGreaterThanOrEqual(8)
+        expect(hour).toBeLessThan(10)
+      }
+
+      // Should query with scheduleId: null (legacy)
+      expect(mockAvailabilityFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ scheduleId: null }),
+        })
+      )
+    })
+
+    it("returns empty slots when no availability rules exist", async () => {
+      mockUserFindUnique.mockResolvedValue(makeUser())
+      mockEventTypeFindUnique.mockResolvedValue(makeEventType())
+      mockAvailabilityScheduleFindFirst.mockResolvedValue(null)
+      mockAvailabilityFindMany.mockResolvedValue([]) // no rules
+
+      const slots = await getAvailableSlots({
+        userId: USER_ID,
+        eventTypeId: EVENT_TYPE_ID,
+        startDate: START,
+        endDate: END,
+        timezone: "UTC",
+      })
+
+      expect(slots).toHaveLength(0)
+    })
+
+    it("returns empty when user not found", async () => {
+      mockUserFindUnique.mockResolvedValue(null)
+      mockEventTypeFindUnique.mockResolvedValue(makeEventType())
+
+      const slots = await getAvailableSlots({
+        userId: USER_ID,
+        eventTypeId: EVENT_TYPE_ID,
+        startDate: START,
+        endDate: END,
+        timezone: "UTC",
+      })
+
+      expect(slots).toHaveLength(0)
+    })
+
+    it("returns empty when event type not found", async () => {
+      mockUserFindUnique.mockResolvedValue(makeUser())
+      mockEventTypeFindUnique.mockResolvedValue(null)
+
+      const slots = await getAvailableSlots({
+        userId: USER_ID,
+        eventTypeId: EVENT_TYPE_ID,
+        startDate: START,
+        endDate: END,
+        timezone: "UTC",
+      })
+
+      expect(slots).toHaveLength(0)
+    })
+  })
+
+  describe("schedule isolation", () => {
+    it("two event types linked to different schedules produce different slots", async () => {
+      const eventTypeA = makeEventType({ id: "et-a", availabilityScheduleId: SCHEDULE_A_ID })
+      const eventTypeB = makeEventType({ id: "et-b", availabilityScheduleId: SCHEDULE_B_ID })
+
+      // Event type A → Schedule A (morning: 08:00–10:00)
+      mockUserFindUnique.mockResolvedValue(makeUser())
+      mockEventTypeFindUnique.mockResolvedValue(eventTypeA)
+      mockAvailabilityFindMany.mockResolvedValue(makeRules(SCHEDULE_A_ID, "08:00", "10:00"))
+
+      const slotsA = await getAvailableSlots({
+        userId: USER_ID,
+        eventTypeId: "et-a",
+        startDate: START,
+        endDate: END,
+        timezone: "UTC",
+      })
+
+      // Event type B → Schedule B (afternoon: 14:00–16:00)
+      vi.clearAllMocks()
+      mockBookingFindMany.mockResolvedValue([])
+      mockCalendarConnectionFindMany.mockResolvedValue([])
+      mockUserFindUnique.mockResolvedValue(makeUser())
+      mockEventTypeFindUnique.mockResolvedValue(eventTypeB)
+      mockAvailabilityFindMany.mockResolvedValue(makeRules(SCHEDULE_B_ID, "14:00", "16:00"))
+
+      const slotsB = await getAvailableSlots({
+        userId: USER_ID,
+        eventTypeId: "et-b",
+        startDate: START,
+        endDate: END,
+        timezone: "UTC",
+      })
+
+      // Slots A should all be morning
+      for (const s of slotsA) {
+        expect(s.start.getUTCHours()).toBeLessThan(12)
+      }
+
+      // Slots B should all be afternoon
+      for (const s of slotsB) {
+        expect(s.start.getUTCHours()).toBeGreaterThanOrEqual(14)
+      }
+
+      // No overlap
+      const aSet = new Set(slotsA.map((s) => s.start.toISOString()))
+      for (const s of slotsB) {
+        expect(aSet.has(s.start.toISOString())).toBe(false)
+      }
+    })
+  })
+})

--- a/src/app/api/availability/route.ts
+++ b/src/app/api/availability/route.ts
@@ -2,31 +2,43 @@ import { NextResponse } from "next/server"
 import { getAuthenticatedUser } from "@/lib/auth"
 import prisma from "@/lib/prisma"
 
-export async function GET() {
+// GET /api/availability — returns legacy (non-scheduled) rules for backward compat
+// Accepts optional ?scheduleId=... to scope to a specific schedule
+export async function GET(req: Request) {
   const user = await getAuthenticatedUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
+  const url = new URL(req.url)
+  const scheduleId = url.searchParams.get("scheduleId")
+
   const availability = await prisma.availability.findMany({
-    where: { userId: user.id },
+    where: {
+      userId: user.id,
+      scheduleId: scheduleId ?? null, // null = legacy/unscoped rules
+    },
     orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }],
   })
   return NextResponse.json(availability)
 }
 
+// PUT /api/availability — replaces rules (legacy or scoped to a schedule)
 export async function PUT(req: Request) {
   const user = await getAuthenticatedUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   const userId = user.id
-  const { rules } = await req.json()
+  const { rules, scheduleId } = await req.json()
 
-  // Delete existing and recreate
-  await prisma.availability.deleteMany({ where: { userId } })
+  // Delete existing rules (scoped to schedule or legacy null)
+  await prisma.availability.deleteMany({
+    where: { userId, scheduleId: scheduleId ?? null },
+  })
 
   if (rules?.length) {
     await prisma.availability.createMany({
       data: rules.map((r: any) => ({
         userId,
+        scheduleId: scheduleId ?? null,
         dayOfWeek: r.dayOfWeek,
         date: r.date ? new Date(r.date) : null,
         startTime: r.startTime,
@@ -37,7 +49,7 @@ export async function PUT(req: Request) {
   }
 
   const updated = await prisma.availability.findMany({
-    where: { userId },
+    where: { userId, scheduleId: scheduleId ?? null },
     orderBy: [{ dayOfWeek: "asc" }],
   })
   return NextResponse.json(updated)

--- a/src/app/api/availability/schedules/[id]/route.ts
+++ b/src/app/api/availability/schedules/[id]/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+// GET /api/availability/schedules/[id]
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const schedule = await prisma.availabilitySchedule.findFirst({
+    where: { id: params.id, userId: user.id },
+    include: {
+      rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] },
+    },
+  })
+
+  if (!schedule) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  return NextResponse.json(schedule)
+}
+
+// PUT /api/availability/schedules/[id] — update name, isDefault, and replace rules
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { name, isDefault, rules } = await req.json()
+
+  const existing = await prisma.availabilitySchedule.findFirst({
+    where: { id: params.id, userId: user.id },
+  })
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 })
+
+  // If marking as default, unset other defaults
+  if (isDefault && !existing.isDefault) {
+    await prisma.availabilitySchedule.updateMany({
+      where: { userId: user.id, isDefault: true },
+      data: { isDefault: false },
+    })
+  }
+
+  // Replace rules: delete existing then recreate
+  await prisma.availability.deleteMany({ where: { scheduleId: params.id } })
+
+  const schedule = await prisma.availabilitySchedule.update({
+    where: { id: params.id },
+    data: {
+      name: name?.trim() ?? existing.name,
+      isDefault: isDefault ?? existing.isDefault,
+      rules: rules?.length
+        ? {
+            create: rules.map((r: any) => ({
+              userId: user.id,
+              dayOfWeek: r.dayOfWeek ?? null,
+              date: r.date ? new Date(r.date) : null,
+              startTime: r.startTime,
+              endTime: r.endTime,
+              enabled: r.enabled ?? true,
+            })),
+          }
+        : undefined,
+    },
+    include: {
+      rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] },
+    },
+  })
+
+  return NextResponse.json(schedule)
+}
+
+// DELETE /api/availability/schedules/[id]
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const existing = await prisma.availabilitySchedule.findFirst({
+    where: { id: params.id, userId: user.id },
+  })
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 })
+
+  // Prevent deleting the only/default schedule if event types use it
+  const linkedCount = await prisma.eventType.count({
+    where: { availabilityScheduleId: params.id },
+  })
+  if (linkedCount > 0) {
+    return NextResponse.json(
+      { error: `Cannot delete: ${linkedCount} event type(s) use this schedule. Reassign them first.` },
+      { status: 409 }
+    )
+  }
+
+  await prisma.availabilitySchedule.delete({ where: { id: params.id } })
+
+  // If deleted schedule was default, promote the oldest remaining
+  if (existing.isDefault) {
+    const next = await prisma.availabilitySchedule.findFirst({
+      where: { userId: user.id },
+      orderBy: { createdAt: "asc" },
+    })
+    if (next) {
+      await prisma.availabilitySchedule.update({
+        where: { id: next.id },
+        data: { isDefault: true },
+      })
+    }
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/availability/schedules/route.ts
+++ b/src/app/api/availability/schedules/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+// GET /api/availability/schedules — list all schedules with their rules
+export async function GET() {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const schedules = await prisma.availabilitySchedule.findMany({
+    where: { userId: user.id },
+    include: {
+      rules: {
+        where: { enabled: true },
+        orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }],
+      },
+      _count: { select: { eventTypes: true } },
+    },
+    orderBy: [{ isDefault: "desc" }, { createdAt: "asc" }],
+  })
+
+  return NextResponse.json(schedules)
+}
+
+// POST /api/availability/schedules — create a new schedule
+export async function POST(req: Request) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { name, rules, isDefault } = await req.json()
+
+  if (!name?.trim()) {
+    return NextResponse.json({ error: "Name is required" }, { status: 400 })
+  }
+
+  // If setting as default, unset previous default
+  if (isDefault) {
+    await prisma.availabilitySchedule.updateMany({
+      where: { userId: user.id, isDefault: true },
+      data: { isDefault: false },
+    })
+  }
+
+  // Check if this is the first schedule — make it default automatically
+  const existingCount = await prisma.availabilitySchedule.count({ where: { userId: user.id } })
+  const makeDefault = isDefault || existingCount === 0
+
+  const schedule = await prisma.availabilitySchedule.create({
+    data: {
+      userId: user.id,
+      name: name.trim(),
+      isDefault: makeDefault,
+      rules: rules?.length
+        ? {
+            create: rules.map((r: any) => ({
+              userId: user.id,
+              dayOfWeek: r.dayOfWeek ?? null,
+              date: r.date ? new Date(r.date) : null,
+              startTime: r.startTime,
+              endTime: r.endTime,
+              enabled: r.enabled ?? true,
+            })),
+          }
+        : undefined,
+    },
+    include: {
+      rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] },
+    },
+  })
+
+  return NextResponse.json(schedule, { status: 201 })
+}

--- a/src/app/api/event-types/[id]/route.ts
+++ b/src/app/api/event-types/[id]/route.ts
@@ -8,7 +8,10 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 
   const eventType = await prisma.eventType.findFirst({
     where: { id: params.id, userId: user.id },
-    include: { questions: { orderBy: { order: "asc" } } },
+    include: {
+      questions: { orderBy: { order: "asc" } },
+      availabilitySchedule: { select: { id: true, name: true } },
+    },
   })
   if (!eventType) return NextResponse.json({ error: "Not found" }, { status: 404 })
   return NextResponse.json(eventType)
@@ -39,6 +42,9 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
       price: body.price,
       isCollective: body.isCollective,
       collectiveMembers: body.collectiveMembers,
+      availabilityScheduleId: body.availabilityScheduleId !== undefined
+        ? body.availabilityScheduleId
+        : undefined,
     },
   })
   return NextResponse.json(eventType)

--- a/src/app/api/event-types/route.ts
+++ b/src/app/api/event-types/route.ts
@@ -9,7 +9,11 @@ export async function GET() {
 
   const eventTypes = await prisma.eventType.findMany({
     where: { userId: user.id },
-    include: { questions: { orderBy: { order: "asc" } }, _count: { select: { bookings: true } } },
+    include: {
+      questions: { orderBy: { order: "asc" } },
+      availabilitySchedule: { select: { id: true, name: true } },
+      _count: { select: { bookings: true } },
+    },
     orderBy: { createdAt: "desc" },
   })
   return NextResponse.json(eventTypes)
@@ -52,6 +56,7 @@ export async function POST(req: Request) {
       currency: body.currency || "usd",
       isCollective: body.isCollective || false,
       collectiveMembers: body.collectiveMembers || [],
+      availabilityScheduleId: body.availabilityScheduleId || null,
       questions: body.questions?.length ? {
         create: body.questions.map((q: any, i: number) => ({
           label: q.label,

--- a/src/app/dashboard/availability/page.tsx
+++ b/src/app/dashboard/availability/page.tsx
@@ -1,99 +1,260 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { Save } from "lucide-react"
+import { Save, Plus, Trash2, ChevronDown, ChevronUp, Star } from "lucide-react"
 
 const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 interface Rule {
+  id?: string
   dayOfWeek: number
   startTime: string
   endTime: string
   enabled: boolean
 }
 
+interface Schedule {
+  id: string
+  name: string
+  isDefault: boolean
+  rules: Rule[]
+  _count?: { eventTypes: number }
+}
+
+const DEFAULT_RULES: Rule[] = DAYS.map((_, i) => ({
+  dayOfWeek: i,
+  startTime: "09:00",
+  endTime: "17:00",
+  enabled: i >= 1 && i <= 5,
+}))
+
+function buildRuleSet(rules: Rule[]): Rule[] {
+  return DAYS.map((_, i) => {
+    const existing = rules.find((r) => r.dayOfWeek === i)
+    return existing ?? { dayOfWeek: i, startTime: "09:00", endTime: "17:00", enabled: false }
+  })
+}
+
 export default function AvailabilityPage() {
-  const [rules, setRules] = useState<Rule[]>([])
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
+  const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [openId, setOpenId] = useState<string | null>(null)
+  const [saving, setSaving] = useState<string | null>(null)
+  const [saved, setSaved] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState("")
+  const [loading, setLoading] = useState(true)
+
+  async function loadSchedules() {
+    const data = await fetch("/api/availability/schedules").then((r) => r.json())
+    setSchedules(data)
+    if (data.length > 0 && !openId) setOpenId(data[0].id)
+    setLoading(false)
+  }
 
   useEffect(() => {
-    fetch("/api/availability").then(r => r.json()).then((data) => {
-      if (data.length === 0) {
-        // Default: Mon-Fri 9-5
-        setRules(DAYS.map((_, i) => ({
-          dayOfWeek: i,
-          startTime: "09:00",
-          endTime: "17:00",
-          enabled: i >= 1 && i <= 5,
-        })))
-      } else {
-        // Group by day
-        const byDay = DAYS.map((_, i) => {
-          const existing = data.find((r: any) => r.dayOfWeek === i)
-          return existing || { dayOfWeek: i, startTime: "09:00", endTime: "17:00", enabled: false }
-        })
-        setRules(byDay)
-      }
-    })
-  }, [])
+    loadSchedules()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function handleSave() {
-    setSaving(true)
-    await fetch("/api/availability", {
+  function updateRule(scheduleId: string, dayIndex: number, field: keyof Rule, value: any) {
+    setSchedules((prev) =>
+      prev.map((s) => {
+        if (s.id !== scheduleId) return s
+        const ruleSet = buildRuleSet(s.rules)
+        ruleSet[dayIndex] = { ...ruleSet[dayIndex], [field]: value }
+        return { ...s, rules: ruleSet }
+      })
+    )
+  }
+
+  async function handleSave(schedule: Schedule) {
+    setSaving(schedule.id)
+    const rulesToSave = buildRuleSet(schedule.rules).filter((r) => r.enabled)
+    await fetch(`/api/availability/schedules/${schedule.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ rules: rules.filter(r => r.enabled) }),
+      body: JSON.stringify({ name: schedule.name, isDefault: schedule.isDefault, rules: rulesToSave }),
     })
-    setSaving(false)
-    setSaved(true)
-    setTimeout(() => setSaved(false), 2000)
+    setSaving(null)
+    setSaved(schedule.id)
+    setTimeout(() => setSaved(null), 2000)
+    loadSchedules()
   }
+
+  async function handleCreate() {
+    if (!newName.trim()) return
+    setCreating(true)
+    const schedule = await fetch("/api/availability/schedules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newName.trim(), rules: DEFAULT_RULES.filter((r) => r.enabled) }),
+    }).then((r) => r.json())
+    setNewName("")
+    setCreating(false)
+    await loadSchedules()
+    setOpenId(schedule.id)
+  }
+
+  async function handleDelete(schedule: Schedule) {
+    if (schedule._count && schedule._count.eventTypes > 0) {
+      alert(`Cannot delete: ${schedule._count.eventTypes} event type(s) use this schedule.`)
+      return
+    }
+    if (!confirm(`Delete schedule "${schedule.name}"? This cannot be undone.`)) return
+    await fetch(`/api/availability/schedules/${schedule.id}`, { method: "DELETE" })
+    await loadSchedules()
+  }
+
+  async function handleSetDefault(schedule: Schedule) {
+    await fetch(`/api/availability/schedules/${schedule.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: schedule.name, isDefault: true, rules: buildRuleSet(schedule.rules).filter((r) => r.enabled) }),
+    })
+    await loadSchedules()
+  }
+
+  if (loading) return <div className="animate-pulse text-gray-400">Loading availability…</div>
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Availability</h1>
-        <button onClick={handleSave} disabled={saving}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2 text-sm">
-          <Save className="w-4 h-4" /> {saving ? "Saving..." : saved ? "Saved ✓" : "Save"}
+        <div>
+          <h1 className="text-2xl font-bold">Availability</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Create multiple schedules and link them to specific event types.
+          </p>
+        </div>
+      </div>
+
+      {/* Create new schedule */}
+      <div className="bg-white border rounded-xl p-4 mb-4 flex items-center gap-3">
+        <input
+          type="text"
+          placeholder="New schedule name (e.g. Weekends)"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+          className="flex-1 border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+        />
+        <button
+          onClick={handleCreate}
+          disabled={creating || !newName.trim()}
+          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2 text-sm"
+        >
+          <Plus className="w-4 h-4" /> {creating ? "Creating…" : "Add Schedule"}
         </button>
       </div>
 
-      <div className="bg-white border rounded-xl divide-y">
-        {rules.map((rule, i) => (
-          <div key={i} className="p-4 flex items-center gap-4">
-            <input type="checkbox" checked={rule.enabled}
-              onChange={e => {
-                const updated = [...rules]
-                updated[i].enabled = e.target.checked
-                setRules(updated)
-              }}
-              className="rounded" />
-            <span className="w-28 text-sm font-medium">{DAYS[rule.dayOfWeek]}</span>
-            {rule.enabled ? (
-              <div className="flex items-center gap-2">
-                <input type="time" value={rule.startTime}
-                  onChange={e => {
-                    const updated = [...rules]
-                    updated[i].startTime = e.target.value
-                    setRules(updated)
-                  }}
-                  className="border rounded px-2 py-1 text-sm" />
-                <span className="text-gray-400">—</span>
-                <input type="time" value={rule.endTime}
-                  onChange={e => {
-                    const updated = [...rules]
-                    updated[i].endTime = e.target.value
-                    setRules(updated)
-                  }}
-                  className="border rounded px-2 py-1 text-sm" />
+      {schedules.length === 0 && (
+        <div className="text-center py-12 text-gray-400">
+          No schedules yet. Create one above.
+        </div>
+      )}
+
+      {/* Schedule list */}
+      <div className="space-y-3">
+        {schedules.map((schedule) => {
+          const isOpen = openId === schedule.id
+          const ruleSet = buildRuleSet(schedule.rules)
+
+          return (
+            <div key={schedule.id} className="bg-white border rounded-xl overflow-hidden">
+              {/* Header */}
+              <div
+                className="p-4 flex items-center justify-between cursor-pointer hover:bg-gray-50"
+                onClick={() => setOpenId(isOpen ? null : schedule.id)}
+              >
+                <div className="flex items-center gap-3">
+                  {isOpen ? <ChevronUp className="w-4 h-4 text-gray-400" /> : <ChevronDown className="w-4 h-4 text-gray-400" />}
+                  <input
+                    type="text"
+                    value={schedule.name}
+                    onChange={(e) => {
+                      e.stopPropagation()
+                      setSchedules((prev) =>
+                        prev.map((s) => (s.id === schedule.id ? { ...s, name: e.target.value } : s))
+                      )
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    className="font-semibold text-sm border-0 border-b border-transparent hover:border-gray-300 focus:border-blue-500 outline-none bg-transparent px-1"
+                  />
+                  {schedule.isDefault && (
+                    <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full flex items-center gap-1">
+                      <Star className="w-3 h-3" /> Default
+                    </span>
+                  )}
+                  {schedule._count && schedule._count.eventTypes > 0 && (
+                    <span className="text-xs text-gray-400">
+                      {schedule._count.eventTypes} event type{schedule._count.eventTypes !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                  {!schedule.isDefault && (
+                    <button
+                      onClick={() => handleSetDefault(schedule)}
+                      title="Set as default"
+                      className="text-xs text-gray-500 hover:text-blue-600 px-2 py-1 rounded hover:bg-gray-100"
+                    >
+                      Set default
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleSave(schedule)}
+                    disabled={saving === schedule.id}
+                    className="bg-blue-600 text-white px-3 py-1.5 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-1.5 text-xs"
+                  >
+                    <Save className="w-3.5 h-3.5" />
+                    {saving === schedule.id ? "Saving…" : saved === schedule.id ? "Saved ✓" : "Save"}
+                  </button>
+                  <button
+                    onClick={() => handleDelete(schedule)}
+                    title="Delete schedule"
+                    className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
               </div>
-            ) : (
-              <span className="text-sm text-gray-400">Unavailable</span>
-            )}
-          </div>
-        ))}
+
+              {/* Rules */}
+              {isOpen && (
+                <div className="border-t divide-y">
+                  {ruleSet.map((rule, i) => (
+                    <div key={i} className="px-4 py-3 flex items-center gap-4">
+                      <input
+                        type="checkbox"
+                        checked={rule.enabled}
+                        onChange={(e) => updateRule(schedule.id, i, "enabled", e.target.checked)}
+                        className="rounded"
+                      />
+                      <span className="w-28 text-sm font-medium">{DAYS[rule.dayOfWeek]}</span>
+                      {rule.enabled ? (
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="time"
+                            value={rule.startTime}
+                            onChange={(e) => updateRule(schedule.id, i, "startTime", e.target.value)}
+                            className="border rounded px-2 py-1 text-sm"
+                          />
+                          <span className="text-gray-400">—</span>
+                          <input
+                            type="time"
+                            value={rule.endTime}
+                            onChange={(e) => updateRule(schedule.id, i, "endTime", e.target.value)}
+                            className="border rounded px-2 py-1 text-sm"
+                          />
+                        </div>
+                      ) : (
+                        <span className="text-sm text-gray-400">Unavailable</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/app/dashboard/event-types/[id]/page.tsx
+++ b/src/app/dashboard/event-types/[id]/page.tsx
@@ -5,14 +5,22 @@ import { useRouter, useParams } from "next/navigation"
 import { ArrowLeft, Save } from "lucide-react"
 import Link from "next/link"
 
+interface AvailabilitySchedule {
+  id: string
+  name: string
+  isDefault: boolean
+}
+
 export default function EditEventTypePage() {
   const params = useParams()
   const router = useRouter()
   const [et, setEt] = useState<any>(null)
   const [saving, setSaving] = useState(false)
+  const [availabilitySchedules, setAvailabilitySchedules] = useState<AvailabilitySchedule[]>([])
 
   useEffect(() => {
     fetch(`/api/event-types/${params.id}`).then(r => r.json()).then(setEt)
+    fetch("/api/availability/schedules").then(r => r.json()).then(setAvailabilitySchedules)
   }, [params.id])
 
   async function handleSave() {
@@ -108,6 +116,31 @@ export default function EditEventTypePage() {
             <input type="number" value={et.maxFutureDays} onChange={e => setEt({ ...et, maxFutureDays: Number(e.target.value) })}
               className="w-full border rounded-lg px-3 py-2" min={1} />
           </div>
+        </div>
+
+        <hr />
+        <h3 className="font-semibold">Availability Schedule</h3>
+        <div>
+          <label className="block text-sm font-medium mb-1">Which schedule controls availability for this event?</label>
+          <select
+            value={et.availabilityScheduleId || ""}
+            onChange={e => setEt({ ...et, availabilityScheduleId: e.target.value || null })}
+            className="w-full border rounded-lg px-3 py-2 max-w-sm"
+          >
+            <option value="">Use default schedule</option>
+            {availabilitySchedules.map(s => (
+              <option key={s.id} value={s.id}>
+                {s.name}{s.isDefault ? " (default)" : ""}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-400 mt-1">
+            Manage schedules in the{" "}
+            <Link href="/dashboard/availability" className="text-blue-600 hover:underline">
+              Availability
+            </Link>{" "}
+            section.
+          </p>
         </div>
 
         <hr />

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -20,13 +20,38 @@ export async function getAvailableSlots(options: AvailabilityOptions): Promise<T
   const { userId, eventTypeId, startDate, endDate, timezone: _timezone } = options
 
   // Get user and event type
-  const [user, eventType, availabilityRules] = await Promise.all([
+  const [user, eventType] = await Promise.all([
     prisma.user.findUnique({ where: { id: userId } }),
     prisma.eventType.findUnique({ where: { id: eventTypeId } }),
-    prisma.availability.findMany({ where: { userId, enabled: true } }),
   ])
 
   if (!user || !eventType) return []
+
+  // Determine which availability rules to use:
+  // 1. Event type's linked schedule (if set)
+  // 2. Default schedule (if any)
+  // 3. Legacy unscoped rules (backward compat)
+  let availabilityRules
+  if (eventType.availabilityScheduleId) {
+    availabilityRules = await prisma.availability.findMany({
+      where: { scheduleId: eventType.availabilityScheduleId, enabled: true },
+    })
+  } else {
+    // Try default schedule first
+    const defaultSchedule = await prisma.availabilitySchedule.findFirst({
+      where: { userId, isDefault: true },
+    })
+    if (defaultSchedule) {
+      availabilityRules = await prisma.availability.findMany({
+        where: { scheduleId: defaultSchedule.id, enabled: true },
+      })
+    } else {
+      // Fall back to legacy unscoped rules
+      availabilityRules = await prisma.availability.findMany({
+        where: { userId, scheduleId: null, enabled: true },
+      })
+    }
+  }
 
   const duration = eventType.duration
   const bufferBefore = eventType.bufferBefore
@@ -137,13 +162,24 @@ export async function getAvailableSlots(options: AvailabilityOptions): Promise<T
 
 export async function initDefaultAvailability(userId: string) {
   const days = [1, 2, 3, 4, 5] // Mon-Fri
-  await prisma.availability.createMany({
-    data: days.map((day) => ({
+
+  // Create a named "Default" schedule
+  const schedule = await prisma.availabilitySchedule.create({
+    data: {
       userId,
-      dayOfWeek: day,
-      startTime: "09:00",
-      endTime: "17:00",
-      enabled: true,
-    })),
+      name: "Default",
+      isDefault: true,
+      rules: {
+        create: days.map((day) => ({
+          userId,
+          dayOfWeek: day,
+          startTime: "09:00",
+          endTime: "17:00",
+          enabled: true,
+        })),
+      },
+    },
   })
+
+  return schedule
 }


### PR DESCRIPTION
## Summary

Implements support for multiple named availability schedules, with each event type able to be linked to a specific schedule.

Closes #16

---

## Changes

### Schema
- New `AvailabilitySchedule` model with `name` and `isDefault` fields
- `Availability` gains `scheduleId` FK (groups rules into named schedules; `null` = legacy)
- `EventType` gains optional `availabilityScheduleId` FK → `AvailabilitySchedule`
- Migration: `20260313000000_add_availability_schedules`

### Backend
- **`GET/POST /api/availability/schedules`** — list and create named schedules
- **`GET/PUT/DELETE /api/availability/schedules/[id]`** — manage individual schedules
- **`/api/availability`** — updated to support `?scheduleId=` scoping; backward-compatible
- **`/api/event-types` + `/api/event-types/[id]`** — accept and return `availabilityScheduleId`
- **`getAvailableSlots`** — resolves availability in order: event type's linked schedule → default schedule → legacy unscoped rules
- **`initDefaultAvailability`** — now creates a named `Default` schedule on user signup

### Frontend
- **Availability page** — fully redesigned to list/create/rename/delete named schedules; each is collapsible with per-day rule editing
- **Event type edit page** — dropdown to select which schedule controls availability for that event type

### Tests
- New test suite: `multiple-availability-schedules.test.ts` (7 tests covering schedule resolution, isolation, and fallback chains)
- Fixed existing `multi-calendar-booking.test.ts` to mock `prisma.availabilitySchedule`
- All 48 tests pass ✅