### PR TITLE
feat: availability schedules per event type

### DIFF
--- a/prisma/migrations/20260313000000_add_availability_schedules/migration.sql
+++ b/prisma/migrations/20260313000000_add_availability_schedules/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "AvailabilitySchedule" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AvailabilitySchedule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AvailabilitySchedule_userId_name_key" ON "AvailabilitySchedule"("userId", "name");
+
+-- AddForeignKey
+ALTER TABLE "AvailabilitySchedule" ADD CONSTRAINT "AvailabilitySchedule_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable: Add scheduleId to Availability
+ALTER TABLE "Availability" ADD COLUMN "scheduleId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Availability" ADD CONSTRAINT "Availability_scheduleId_fkey" FOREIGN KEY ("scheduleId") REFERENCES "AvailabilitySchedule"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable: Add availabilityScheduleId to EventType
+ALTER TABLE "EventType" ADD COLUMN "availabilityScheduleId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "EventType" ADD CONSTRAINT "EventType_availabilityScheduleId_fkey" FOREIGN KEY ("availabilityScheduleId") REFERENCES "AvailabilitySchedule"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,13 +33,14 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  eventTypes     EventType[]
-  bookings       Booking[]
-  availability   Availability[]
-  calendarConnections CalendarConnection[]
-  webhooks       Webhook[]
-  contacts       Contact[]
-  documents      Document[]
+  eventTypes            EventType[]
+  bookings              Booking[]
+  availability          Availability[]
+  availabilitySchedules AvailabilitySchedule[]
+  calendarConnections   CalendarConnection[]
+  webhooks              Webhook[]
+  contacts              Contact[]
+  documents             Document[]
 }
 
 enum Plan {
@@ -77,6 +78,10 @@ model EventType {
   // Collective scheduling
   isCollective   Boolean @default(false)
   collectiveMembers String[] // user IDs
+
+  // Availability schedule
+  availabilityScheduleId String?
+  availabilitySchedule   AvailabilitySchedule? @relation(fields: [availabilityScheduleId], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -175,21 +180,41 @@ enum BookingStatus {
   NO_SHOW
 }
 
+// ─── Availability Schedules ───
+
+model AvailabilitySchedule {
+  id        String  @id @default(cuid())
+  userId    String
+  name      String
+  isDefault Boolean @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user       User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rules      Availability[]
+  eventTypes EventType[]
+
+  @@unique([userId, name])
+}
+
 // ─── Availability ───
 
 model Availability {
-  id     String @id @default(cuid())
-  userId String
-  
+  id         String  @id @default(cuid())
+  userId     String
+  scheduleId String?
+
   // Day of week (0=Sunday, 6=Saturday) or specific date
   dayOfWeek Int?      // 0-6
   date      DateTime? // for date-specific overrides
-  
+
   startTime String // "09:00"
   endTime   String // "17:00"
   enabled   Boolean @default(true)
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user     User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  schedule AvailabilitySchedule? @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
 }
 
 // ─── Calendar Connections ───

--- a/src/__tests__/integration/availability-schedules.test.ts
+++ b/src/__tests__/integration/availability-schedules.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { getAvailableSlots } from "@/lib/availability"
+
+// ─── Mock Prisma ───
+
+const mockUserFindUnique = vi.fn()
+const mockEventTypeFindUnique = vi.fn()
+const mockAvailabilityFindMany = vi.fn()
+const mockAvailabilityScheduleFindFirst = vi.fn()
+const mockBookingFindMany = vi.fn()
+const mockCalendarConnectionFindMany = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: { findUnique: (...args: any[]) => mockUserFindUnique(...args) },
+    eventType: { findUnique: (...args: any[]) => mockEventTypeFindUnique(...args) },
+    availability: { findMany: (...args: any[]) => mockAvailabilityFindMany(...args) },
+    availabilitySchedule: { findFirst: (...args: any[]) => mockAvailabilityScheduleFindFirst(...args) },
+    booking: { findMany: (...args: any[]) => mockBookingFindMany(...args) },
+    calendarConnection: { findMany: (...args: any[]) => mockCalendarConnectionFindMany(...args) },
+  },
+}))
+
+vi.mock("@/lib/calendar/google-calendar", () => ({
+  fetchGoogleCalendarEvents: vi.fn().mockResolvedValue([]),
+  refreshGoogleToken: vi.fn(),
+}))
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }))
+vi.mock("@/lib/auth", () => ({ getAuthenticatedUser: vi.fn() }))
+
+// ─── Test Data ───
+
+const USER_ID = "user-1"
+const EVENT_TYPE_ID = "et-1"
+const SCHEDULE_A_ID = "sched-a"
+const SCHEDULE_B_ID = "sched-b"
+
+const FAR_FUTURE = new Date("2026-09-15T00:00:00Z")
+const FAR_FUTURE_END = new Date("2026-09-16T00:00:00Z")
+
+function makeUser(overrides = {}) {
+  return { id: USER_ID, timezone: "UTC", plan: "PRO", ...overrides }
+}
+
+function makeEventType(overrides = {}) {
+  return {
+    id: EVENT_TYPE_ID,
+    userId: USER_ID,
+    duration: 30,
+    bufferBefore: 0,
+    bufferAfter: 0,
+    minNotice: 0,
+    maxFutureDays: 365,
+    dailyLimit: null,
+    weeklyLimit: null,
+    availabilityScheduleId: null,
+    ...overrides,
+  }
+}
+
+function makeRules(startTime: string, endTime: string) {
+  return Array.from({ length: 7 }, (_, i) => ({
+    id: `rule-${i}`,
+    userId: USER_ID,
+    scheduleId: null,
+    dayOfWeek: i,
+    date: null,
+    startTime,
+    endTime,
+    enabled: true,
+  }))
+}
+
+// ─── Tests ───
+
+describe("Availability Schedules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCalendarConnectionFindMany.mockResolvedValue([])
+    mockBookingFindMany.mockResolvedValue([])
+  })
+
+  it("uses legacy rules when event type has no schedule and no default schedule exists", async () => {
+    mockUserFindUnique.mockResolvedValue(makeUser())
+    mockEventTypeFindUnique.mockResolvedValue(makeEventType({ availabilityScheduleId: null }))
+    mockAvailabilityScheduleFindFirst.mockResolvedValue(null) // no default schedule
+
+    // Legacy rules: 08:00-18:00
+    mockAvailabilityFindMany.mockResolvedValue(makeRules("08:00", "18:00"))
+
+    const slots = await getAvailableSlots({
+      userId: USER_ID,
+      eventTypeId: EVENT_TYPE_ID,
+      startDate: FAR_FUTURE,
+      endDate: FAR_FUTURE_END,
+      timezone: "UTC",
+    })
+
+    expect(slots.length).toBeGreaterThan(0)
+    // Should query availability with scheduleId: null
+    expect(mockAvailabilityFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: USER_ID, scheduleId: null, enabled: true }),
+      })
+    )
+  })
+
+  it("uses the event type's linked schedule when set", async () => {
+    mockUserFindUnique.mockResolvedValue(makeUser())
+    mockEventTypeFindUnique.mockResolvedValue(
+      makeEventType({ availabilityScheduleId: SCHEDULE_A_ID })
+    )
+
+    // Schedule A rules: 10:00-12:00 (narrow window)
+    const narrowRules = makeRules("10:00", "12:00").map((r) => ({
+      ...r,
+      scheduleId: SCHEDULE_A_ID,
+    }))
+    mockAvailabilityFindMany.mockResolvedValue(narrowRules)
+
+    const slots = await getAvailableSlots({
+      userId: USER_ID,
+      eventTypeId: EVENT_TYPE_ID,
+      startDate: FAR_FUTURE,
+      endDate: FAR_FUTURE_END,
+      timezone: "UTC",
+    })
+
+    // Should query by scheduleId
+    expect(mockAvailabilityFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ scheduleId: SCHEDULE_A_ID, enabled: true }),
+      })
+    )
+
+    // All slots should be within 10:00-12:00
+    for (const slot of slots) {
+      expect(slot.start.getUTCHours()).toBeGreaterThanOrEqual(10)
+      expect(slot.end.getUTCHours()).toBeLessThanOrEqual(12)
+    }
+  })
+
+  it("falls back to default schedule when event type has no linked schedule", async () => {
+    mockUserFindUnique.mockResolvedValue(makeUser())
+    mockEventTypeFindUnique.mockResolvedValue(makeEventType({ availabilityScheduleId: null }))
+
+    // Default schedule exists
+    mockAvailabilityScheduleFindFirst.mockResolvedValue({
+      id: SCHEDULE_B_ID,
+      userId: USER_ID,
+      name: "Default",
+      isDefault: true,
+    })
+
+    mockAvailabilityFindMany.mockResolvedValue(
+      makeRules("09:00", "17:00").map((r) => ({ ...r, scheduleId: SCHEDULE_B_ID }))
+    )
+
+    const slots = await getAvailableSlots({
+      userId: USER_ID,
+      eventTypeId: EVENT_TYPE_ID,
+      startDate: FAR_FUTURE,
+      endDate: FAR_FUTURE_END,
+      timezone: "UTC",
+    })
+
+    expect(slots.length).toBeGreaterThan(0)
+    expect(mockAvailabilityFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ scheduleId: SCHEDULE_B_ID, enabled: true }),
+      })
+    )
+  })
+
+  it("different event types use different schedules producing different slots", async () => {
+    mockUserFindUnique.mockResolvedValue(makeUser())
+    mockBookingFindMany.mockResolvedValue([])
+
+    // Event type A -> Schedule A (mornings only: 08:00-12:00)
+    mockEventTypeFindUnique.mockResolvedValue(
+      makeEventType({ id: "et-a", availabilityScheduleId: SCHEDULE_A_ID })
+    )
+    mockAvailabilityFindMany.mockResolvedValue(
+      makeRules("08:00", "12:00").map((r) => ({ ...r, scheduleId: SCHEDULE_A_ID }))
+    )
+
+    const morningSlots = await getAvailableSlots({
+      userId: USER_ID,
+      eventTypeId: "et-a",
+      startDate: FAR_FUTURE,
+      endDate: FAR_FUTURE_END,
+      timezone: "UTC",
+    })
+
+    vi.clearAllMocks()
+    mockCalendarConnectionFindMany.mockResolvedValue([])
+    mockBookingFindMany.mockResolvedValue([])
+    mockUserFindUnique.mockResolvedValue(makeUser())
+
+    // Event type B -> Schedule B (afternoons only: 14:00-18:00)
+    mockEventTypeFindUnique.mockResolvedValue(
+      makeEventType({ id: "et-b", availabilityScheduleId: SCHEDULE_B_ID })
+    )
+    mockAvailabilityFindMany.mockResolvedValue(
+      makeRules("14:00", "18:00").map((r) => ({ ...r, scheduleId: SCHEDULE_B_ID }))
+    )
+
+    const afternoonSlots = await getAvailableSlots({
+      userId: USER_ID,
+      eventTypeId: "et-b",
+      startDate: FAR_FUTURE,
+      endDate: FAR_FUTURE_END,
+      timezone: "UTC",
+    })
+
+    // Morning slots should be before noon
+    for (const slot of morningSlots) {
+      expect(slot.start.getUTCHours()).toBeLessThan(12)
+    }
+
+    // Afternoon slots should be at or after 14:00
+    for (const slot of afternoonSlots) {
+      expect(slot.start.getUTCHours()).toBeGreaterThanOrEqual(14)
+    }
+
+    // The two sets should not overlap
+    const morningTimes = new Set(morningSlots.map((s) => s.start.getTime()))
+    const hasOverlap = afternoonSlots.some((s) => morningTimes.has(s.start.getTime()))
+    expect(hasOverlap).toBe(false)
+  })
+
+  it("returns empty slots when event type links to a schedule with no enabled rules", async () => {
+    mockUserFindUnique.mockResolvedValue(makeUser())
+    mockEventTypeFindUnique.mockResolvedValue(
+      makeEventType({ availabilityScheduleId: SCHEDULE_A_ID })
+    )
+    mockAvailabilityFindMany.mockResolvedValue([]) // no rules
+
+    const slots = await getAvailableSlots({
+      userId: USER_ID,
+      eventTypeId: EVENT_TYPE_ID,
+      startDate: FAR_FUTURE,
+      endDate: FAR_FUTURE_END,
+      timezone: "UTC",
+    })
+
+    expect(slots).toHaveLength(0)
+  })
+
+  it("linked schedule takes priority over default schedule", async () => {
+    mockUserFindUnique.mockResolvedValue(makeUser())
+    mockEventTypeFindUnique.mockResolvedValue(
+      makeEventType({ availabilityScheduleId: SCHEDULE_A_ID })
+    )
+
+    // Should NOT look up default schedule when event type has explicit link
+    mockAvailabilityFindMany.mockResolvedValue(makeRules("06:00", "08:00"))
+
+    await getAvailableSlots({
+      userId: USER_ID,
+      eventTypeId: EVENT_TYPE_ID,
+      startDate: FAR_FUTURE,
+      endDate: FAR_FUTURE_END,
+      timezone: "UTC",
+    })
+
+    // Should not have queried for default schedule
+    expect(mockAvailabilityScheduleFindFirst).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/integration/multi-calendar-booking.test.ts
+++ b/src/__tests__/integration/multi-calendar-booking.test.ts
@@ -42,6 +42,9 @@ vi.mock("@/lib/prisma", () => ({
     booking: {
       findMany: (...args: any[]) => mockBookingFindMany(...args),
     },
+    availabilitySchedule: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
   },
 }))
 

--- a/src/app/api/availability/route.ts
+++ b/src/app/api/availability/route.ts
@@ -2,12 +2,18 @@ import { NextResponse } from "next/server"
 import { getAuthenticatedUser } from "@/lib/auth"
 import prisma from "@/lib/prisma"
 
-export async function GET() {
+export async function GET(req: Request) {
   const user = await getAuthenticatedUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
+  const url = new URL(req.url)
+  const scheduleId = url.searchParams.get("scheduleId")
+
   const availability = await prisma.availability.findMany({
-    where: { userId: user.id },
+    where: {
+      userId: user.id,
+      ...(scheduleId ? { scheduleId } : { scheduleId: null }),
+    },
     orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }],
   })
   return NextResponse.json(availability)
@@ -18,15 +24,18 @@ export async function PUT(req: Request) {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   const userId = user.id
-  const { rules } = await req.json()
+  const { rules, scheduleId } = await req.json()
 
-  // Delete existing and recreate
-  await prisma.availability.deleteMany({ where: { userId } })
+  // Delete existing rules (scoped to schedule or legacy null)
+  await prisma.availability.deleteMany({
+    where: { userId, ...(scheduleId ? { scheduleId } : { scheduleId: null }) },
+  })
 
   if (rules?.length) {
     await prisma.availability.createMany({
       data: rules.map((r: any) => ({
         userId,
+        scheduleId: scheduleId ?? null,
         dayOfWeek: r.dayOfWeek,
         date: r.date ? new Date(r.date) : null,
         startTime: r.startTime,
@@ -37,7 +46,7 @@ export async function PUT(req: Request) {
   }
 
   const updated = await prisma.availability.findMany({
-    where: { userId },
+    where: { userId, ...(scheduleId ? { scheduleId } : { scheduleId: null }) },
     orderBy: [{ dayOfWeek: "asc" }],
   })
   return NextResponse.json(updated)

--- a/src/app/api/availability/schedules/[id]/route.ts
+++ b/src/app/api/availability/schedules/[id]/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const schedule = await prisma.availabilitySchedule.findFirst({
+    where: { id: params.id, userId: user.id },
+    include: {
+      rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] },
+      _count: { select: { eventTypes: true } },
+    },
+  })
+  if (!schedule) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  return NextResponse.json(schedule)
+}
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { name, isDefault, rules } = await req.json()
+
+  // If setting as default, unset other defaults
+  if (isDefault) {
+    await prisma.availabilitySchedule.updateMany({
+      where: { userId: user.id, isDefault: true, id: { not: params.id } },
+      data: { isDefault: false },
+    })
+  }
+
+  // Replace rules: delete existing, create new
+  await prisma.availability.deleteMany({
+    where: { scheduleId: params.id },
+  })
+
+  const schedule = await prisma.availabilitySchedule.update({
+    where: { id: params.id },
+    data: {
+      name: name?.trim(),
+      isDefault,
+      rules: rules?.length
+        ? {
+            create: rules.map((r: any) => ({
+              userId: user.id,
+              dayOfWeek: r.dayOfWeek,
+              date: r.date ? new Date(r.date) : null,
+              startTime: r.startTime,
+              endTime: r.endTime,
+              enabled: r.enabled ?? true,
+            })),
+          }
+        : undefined,
+    },
+    include: {
+      rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] },
+      _count: { select: { eventTypes: true } },
+    },
+  })
+
+  return NextResponse.json(schedule)
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const schedule = await prisma.availabilitySchedule.findFirst({
+    where: { id: params.id, userId: user.id },
+    include: { _count: { select: { eventTypes: true } } },
+  })
+  if (!schedule) return NextResponse.json({ error: "Not found" }, { status: 404 })
+
+  if (schedule._count.eventTypes > 0) {
+    return NextResponse.json(
+      { error: "Cannot delete: schedule is assigned to event types" },
+      { status: 400 }
+    )
+  }
+
+  await prisma.availabilitySchedule.delete({ where: { id: params.id } })
+
+  // If we deleted the default, promote the oldest remaining
+  if (schedule.isDefault) {
+    const oldest = await prisma.availabilitySchedule.findFirst({
+      where: { userId: user.id },
+      orderBy: { createdAt: "asc" },
+    })
+    if (oldest) {
+      await prisma.availabilitySchedule.update({
+        where: { id: oldest.id },
+        data: { isDefault: true },
+      })
+    }
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/availability/schedules/route.ts
+++ b/src/app/api/availability/schedules/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+export async function GET() {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const schedules = await prisma.availabilitySchedule.findMany({
+    where: { userId: user.id },
+    include: {
+      rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] },
+      _count: { select: { eventTypes: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  })
+  return NextResponse.json(schedules)
+}
+
+export async function POST(req: Request) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { name, rules } = await req.json()
+  if (!name?.trim()) {
+    return NextResponse.json({ error: "Name is required" }, { status: 400 })
+  }
+
+  // If this is the first schedule, make it default
+  const count = await prisma.availabilitySchedule.count({ where: { userId: user.id } })
+  const isDefault = count === 0
+
+  const schedule = await prisma.availabilitySchedule.create({
+    data: {
+      userId: user.id,
+      name: name.trim(),
+      isDefault,
+      rules: rules?.length
+        ? {
+            create: rules.map((r: any) => ({
+              userId: user.id,
+              dayOfWeek: r.dayOfWeek,
+              date: r.date ? new Date(r.date) : null,
+              startTime: r.startTime,
+              endTime: r.endTime,
+              enabled: r.enabled ?? true,
+            })),
+          }
+        : undefined,
+    },
+    include: { rules: true },
+  })
+
+  return NextResponse.json(schedule)
+}

--- a/src/app/api/event-types/[id]/route.ts
+++ b/src/app/api/event-types/[id]/route.ts
@@ -8,7 +8,10 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 
   const eventType = await prisma.eventType.findFirst({
     where: { id: params.id, userId: user.id },
-    include: { questions: { orderBy: { order: "asc" } } },
+    include: {
+      questions: { orderBy: { order: "asc" } },
+      availabilitySchedule: { select: { id: true, name: true } },
+    },
   })
   if (!eventType) return NextResponse.json({ error: "Not found" }, { status: 404 })
   return NextResponse.json(eventType)
@@ -39,6 +42,9 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
       price: body.price,
       isCollective: body.isCollective,
       collectiveMembers: body.collectiveMembers,
+      ...(body.availabilityScheduleId !== undefined && {
+        availabilityScheduleId: body.availabilityScheduleId,
+      }),
     },
   })
   return NextResponse.json(eventType)

--- a/src/app/api/event-types/route.ts
+++ b/src/app/api/event-types/route.ts
@@ -9,7 +9,11 @@ export async function GET() {
 
   const eventTypes = await prisma.eventType.findMany({
     where: { userId: user.id },
-    include: { questions: { orderBy: { order: "asc" } }, _count: { select: { bookings: true } } },
+    include: {
+      questions: { orderBy: { order: "asc" } },
+      availabilitySchedule: { select: { id: true, name: true } },
+      _count: { select: { bookings: true } },
+    },
     orderBy: { createdAt: "desc" },
   })
   return NextResponse.json(eventTypes)
@@ -52,6 +56,7 @@ export async function POST(req: Request) {
       currency: body.currency || "usd",
       isCollective: body.isCollective || false,
       collectiveMembers: body.collectiveMembers || [],
+      availabilityScheduleId: body.availabilityScheduleId || null,
       questions: body.questions?.length ? {
         create: body.questions.map((q: any, i: number) => ({
           label: q.label,

--- a/src/app/dashboard/availability/page.tsx
+++ b/src/app/dashboard/availability/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { Save } from "lucide-react"
+import { Save, Plus, Trash2, Star } from "lucide-react"
 
 const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
@@ -12,89 +12,218 @@ interface Rule {
   enabled: boolean
 }
 
+interface Schedule {
+  id: string
+  name: string
+  isDefault: boolean
+  rules: Rule[]
+  _count?: { eventTypes: number }
+}
+
+function buildRuleSet(rules: Rule[]): Rule[] {
+  return DAYS.map((_, i) => {
+    const existing = rules.find((r) => r.dayOfWeek === i)
+    return existing ?? { dayOfWeek: i, startTime: "09:00", endTime: "17:00", enabled: false }
+  })
+}
+
 export default function AvailabilityPage() {
+  const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
   const [rules, setRules] = useState<Rule[]>([])
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState("")
+  const [loading, setLoading] = useState(true)
+
+  async function loadSchedules() {
+    const data = await fetch("/api/availability/schedules").then((r) => r.json())
+    setSchedules(data)
+    return data as Schedule[]
+  }
 
   useEffect(() => {
-    fetch("/api/availability").then(r => r.json()).then((data) => {
-      if (data.length === 0) {
-        // Default: Mon-Fri 9-5
-        setRules(DAYS.map((_, i) => ({
-          dayOfWeek: i,
-          startTime: "09:00",
-          endTime: "17:00",
-          enabled: i >= 1 && i <= 5,
-        })))
-      } else {
-        // Group by day
-        const byDay = DAYS.map((_, i) => {
-          const existing = data.find((r: any) => r.dayOfWeek === i)
-          return existing || { dayOfWeek: i, startTime: "09:00", endTime: "17:00", enabled: false }
-        })
-        setRules(byDay)
+    loadSchedules().then((data) => {
+      if (data.length > 0) {
+        const def = data.find((s: Schedule) => s.isDefault) || data[0]
+        setActiveId(def.id)
+        setRules(buildRuleSet(def.rules))
       }
+      setLoading(false)
     })
   }, [])
 
+  function selectSchedule(id: string) {
+    setActiveId(id)
+    const s = schedules.find((s) => s.id === id)
+    if (s) setRules(buildRuleSet(s.rules))
+    setSaved(false)
+  }
+
+  const activeSchedule = schedules.find((s) => s.id === activeId)
+
   async function handleSave() {
+    if (!activeId || !activeSchedule) return
     setSaving(true)
-    await fetch("/api/availability", {
+    await fetch(`/api/availability/schedules/${activeId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ rules: rules.filter(r => r.enabled) }),
+      body: JSON.stringify({
+        name: activeSchedule.name,
+        isDefault: activeSchedule.isDefault,
+        rules: rules.filter((r) => r.enabled),
+      }),
     })
+    await loadSchedules()
     setSaving(false)
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
   }
 
+  async function handleCreate() {
+    if (!newName.trim()) return
+    setCreating(true)
+    const defaultRules = DAYS.map((_, i) => ({
+      dayOfWeek: i,
+      startTime: "09:00",
+      endTime: "17:00",
+      enabled: i >= 1 && i <= 5,
+    }))
+    const schedule = await fetch("/api/availability/schedules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newName.trim(), rules: defaultRules.filter((r) => r.enabled) }),
+    }).then((r) => r.json())
+    setNewName("")
+    setCreating(false)
+    const data = await loadSchedules()
+    selectSchedule(schedule.id)
+  }
+
+  async function handleDelete() {
+    if (!activeSchedule) return
+    if (activeSchedule._count && activeSchedule._count.eventTypes > 0) {
+      alert(`Cannot delete: ${activeSchedule._count.eventTypes} event type(s) use this schedule.`)
+      return
+    }
+    if (!confirm(`Delete "${activeSchedule.name}"?`)) return
+    await fetch(`/api/availability/schedules/${activeSchedule.id}`, { method: "DELETE" })
+    const data = await loadSchedules()
+    if (data.length > 0) {
+      selectSchedule(data[0].id)
+    } else {
+      setActiveId(null)
+      setRules([])
+    }
+  }
+
+  async function handleSetDefault() {
+    if (!activeId || !activeSchedule) return
+    await fetch(`/api/availability/schedules/${activeId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: activeSchedule.name,
+        isDefault: true,
+        rules: rules.filter((r) => r.enabled),
+      }),
+    })
+    await loadSchedules()
+  }
+
+  if (loading) return <div className="animate-pulse text-gray-400">Loading...</div>
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Availability</h1>
-        <button onClick={handleSave} disabled={saving}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2 text-sm">
-          <Save className="w-4 h-4" /> {saving ? "Saving..." : saved ? "Saved ✓" : "Save"}
-        </button>
+        {activeSchedule && (
+          <div className="flex items-center gap-2">
+            {!activeSchedule.isDefault && (
+              <button onClick={handleSetDefault}
+                className="text-sm text-gray-500 hover:text-blue-600 px-3 py-2 rounded-lg hover:bg-gray-100 flex items-center gap-1">
+                <Star className="w-3.5 h-3.5" /> Set as default
+              </button>
+            )}
+            <button onClick={handleDelete}
+              className="text-sm text-gray-400 hover:text-red-500 px-3 py-2 rounded-lg hover:bg-red-50 flex items-center gap-1">
+              <Trash2 className="w-3.5 h-3.5" /> Delete
+            </button>
+            <button onClick={handleSave} disabled={saving}
+              className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2 text-sm">
+              <Save className="w-4 h-4" /> {saving ? "Saving..." : saved ? "Saved" : "Save"}
+            </button>
+          </div>
+        )}
       </div>
 
-      <div className="bg-white border rounded-xl divide-y">
-        {rules.map((rule, i) => (
-          <div key={i} className="p-4 flex items-center gap-4">
-            <input type="checkbox" checked={rule.enabled}
-              onChange={e => {
-                const updated = [...rules]
-                updated[i].enabled = e.target.checked
-                setRules(updated)
-              }}
-              className="rounded" />
-            <span className="w-28 text-sm font-medium">{DAYS[rule.dayOfWeek]}</span>
-            {rule.enabled ? (
-              <div className="flex items-center gap-2">
-                <input type="time" value={rule.startTime}
-                  onChange={e => {
-                    const updated = [...rules]
-                    updated[i].startTime = e.target.value
-                    setRules(updated)
-                  }}
-                  className="border rounded px-2 py-1 text-sm" />
-                <span className="text-gray-400">—</span>
-                <input type="time" value={rule.endTime}
-                  onChange={e => {
-                    const updated = [...rules]
-                    updated[i].endTime = e.target.value
-                    setRules(updated)
-                  }}
-                  className="border rounded px-2 py-1 text-sm" />
-              </div>
-            ) : (
-              <span className="text-sm text-gray-400">Unavailable</span>
-            )}
-          </div>
+      {/* Schedule tabs + create */}
+      <div className="flex items-center gap-2 mb-4 flex-wrap">
+        {schedules.map((s) => (
+          <button key={s.id} onClick={() => selectSchedule(s.id)}
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
+              s.id === activeId
+                ? "bg-blue-600 text-white border-blue-600"
+                : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+            }`}>
+            {s.name} {s.isDefault && "(default)"}
+          </button>
         ))}
+        <div className="flex items-center gap-1 ml-2">
+          <input type="text" placeholder="New schedule..." value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            className="border rounded-lg px-2 py-1.5 text-sm w-40 focus:ring-2 focus:ring-blue-500 outline-none" />
+          <button onClick={handleCreate} disabled={creating || !newName.trim()}
+            className="p-1.5 text-blue-600 hover:bg-blue-50 rounded-lg disabled:opacity-50">
+            <Plus className="w-4 h-4" />
+          </button>
+        </div>
       </div>
+
+      {/* Rules editor */}
+      {activeSchedule ? (
+        <div className="bg-white border rounded-xl divide-y">
+          {rules.map((rule, i) => (
+            <div key={i} className="p-4 flex items-center gap-4">
+              <input type="checkbox" checked={rule.enabled}
+                onChange={(e) => {
+                  const updated = [...rules]
+                  updated[i] = { ...updated[i], enabled: e.target.checked }
+                  setRules(updated)
+                }}
+                className="rounded" />
+              <span className="w-28 text-sm font-medium">{DAYS[rule.dayOfWeek]}</span>
+              {rule.enabled ? (
+                <div className="flex items-center gap-2">
+                  <input type="time" value={rule.startTime}
+                    onChange={(e) => {
+                      const updated = [...rules]
+                      updated[i] = { ...updated[i], startTime: e.target.value }
+                      setRules(updated)
+                    }}
+                    className="border rounded px-2 py-1 text-sm" />
+                  <span className="text-gray-400">&mdash;</span>
+                  <input type="time" value={rule.endTime}
+                    onChange={(e) => {
+                      const updated = [...rules]
+                      updated[i] = { ...updated[i], endTime: e.target.value }
+                      setRules(updated)
+                    }}
+                    className="border rounded px-2 py-1 text-sm" />
+                </div>
+              ) : (
+                <span className="text-sm text-gray-400">Unavailable</span>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12 text-gray-400">
+          Create a schedule to get started.
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/dashboard/availability/page.tsx
+++ b/src/app/dashboard/availability/page.tsx
@@ -97,7 +97,7 @@ export default function AvailabilityPage() {
     }).then((r) => r.json())
     setNewName("")
     setCreating(false)
-    const data = await loadSchedules()
+    await loadSchedules()
     selectSchedule(schedule.id)
   }
 

--- a/src/app/dashboard/event-types/[id]/page.tsx
+++ b/src/app/dashboard/event-types/[id]/page.tsx
@@ -5,14 +5,22 @@ import { useRouter, useParams } from "next/navigation"
 import { ArrowLeft, Save } from "lucide-react"
 import Link from "next/link"
 
+interface ScheduleOption {
+  id: string
+  name: string
+  isDefault: boolean
+}
+
 export default function EditEventTypePage() {
   const params = useParams()
   const router = useRouter()
   const [et, setEt] = useState<any>(null)
   const [saving, setSaving] = useState(false)
+  const [schedules, setSchedules] = useState<ScheduleOption[]>([])
 
   useEffect(() => {
     fetch(`/api/event-types/${params.id}`).then(r => r.json()).then(setEt)
+    fetch("/api/availability/schedules").then(r => r.json()).then(setSchedules)
   }, [params.id])
 
   async function handleSave() {
@@ -108,6 +116,31 @@ export default function EditEventTypePage() {
             <input type="number" value={et.maxFutureDays} onChange={e => setEt({ ...et, maxFutureDays: Number(e.target.value) })}
               className="w-full border rounded-lg px-3 py-2" min={1} />
           </div>
+        </div>
+
+        <hr />
+        <h3 className="font-semibold">Availability Schedule</h3>
+        <div>
+          <label className="block text-sm font-medium mb-1">Which schedule controls this event&apos;s availability?</label>
+          <select
+            value={et.availabilityScheduleId || ""}
+            onChange={e => setEt({ ...et, availabilityScheduleId: e.target.value || null })}
+            className="w-full border rounded-lg px-3 py-2 max-w-sm"
+          >
+            <option value="">Default schedule</option>
+            {schedules.map((s: ScheduleOption) => (
+              <option key={s.id} value={s.id}>
+                {s.name}{s.isDefault ? " (default)" : ""}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-400 mt-1">
+            Manage schedules on the{" "}
+            <Link href="/dashboard/availability" className="text-blue-600 hover:underline">
+              Availability
+            </Link>{" "}
+            page.
+          </p>
         </div>
 
         <hr />

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -20,13 +20,32 @@ export async function getAvailableSlots(options: AvailabilityOptions): Promise<T
   const { userId, eventTypeId, startDate, endDate, timezone: _timezone } = options
 
   // Get user and event type
-  const [user, eventType, availabilityRules] = await Promise.all([
+  const [user, eventType] = await Promise.all([
     prisma.user.findUnique({ where: { id: userId } }),
     prisma.eventType.findUnique({ where: { id: eventTypeId } }),
-    prisma.availability.findMany({ where: { userId, enabled: true } }),
   ])
 
   if (!user || !eventType) return []
+
+  // Resolve availability rules:
+  // 1. Event type's linked schedule (if set)
+  // 2. User's default schedule (if any)
+  // 3. Legacy unscoped rules (scheduleId is null)
+  let scheduleId: string | null = null
+  if (eventType.availabilityScheduleId) {
+    scheduleId = eventType.availabilityScheduleId
+  } else {
+    const defaultSchedule = await prisma.availabilitySchedule.findFirst({
+      where: { userId, isDefault: true },
+    })
+    if (defaultSchedule) scheduleId = defaultSchedule.id
+  }
+
+  const availabilityRules = await prisma.availability.findMany({
+    where: scheduleId
+      ? { scheduleId, enabled: true }
+      : { userId, scheduleId: null, enabled: true },
+  })
 
   const duration = eventType.duration
   const bufferBefore = eventType.bufferBefore


### PR DESCRIPTION
## Summary

This PR adds the ability to define different availability schedules for different event types.

## Changes

### Database Schema
- Added AvailabilitySchedule model to define named availability schedules
- Added availabilityScheduleId field to EventType to link events to specific schedules
- Modified Availability model to support both scoped rules (per schedule) and legacy unscoped rules

### API Endpoints
- GET /api/availability/schedules - List all availability schedules for a user
- POST /api/availability/schedules - Create a new availability schedule with rules
- PUT /api/availability/schedules/[id] - Update an existing schedule
- DELETE /api/availability/schedules/[id] - Delete a schedule

### Backend Logic
- Updated getAvailableSlots() to use cascading availability resolution:
  1. Event type's linked schedule (if set)
  2. User's default schedule (if any)
  3. Legacy unscoped rules (for backward compatibility)

### Frontend UI
- New availability management dashboard with:
  - Create and manage multiple named schedules
  - Set per-day availability hours
  - Mark schedules as default
  - See which event types use each schedule
- Updated event type editor to select which schedule controls its availability

### Testing
- Comprehensive integration tests covering all resolution scenarios

## Technical Details

The feature implements a three-tier availability resolution system for flexible scheduling.