### PR TITLE
feat: add privacy policy and terms of service pages

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Privacy Policy - TinyCal",
+}
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50">
+        <div className="max-w-4xl mx-auto px-6 h-16 flex items-center">
+          <Link href="/" className="text-xl font-bold text-blue-600">
+            Tiny<span className="text-gray-900">Cal</span>
+          </Link>
+        </div>
+      </nav>
+
+      <div className="max-w-3xl mx-auto px-6 py-16 prose prose-gray">
+        <h1>Privacy Policy</h1>
+        <p className="text-gray-500">Last updated: April 1, 2026</p>
+
+        <p>
+          TinyCal (&quot;we&quot;, &quot;our&quot;, or &quot;us&quot;) is operated by Zenith Studio. This Privacy Policy
+          explains how we collect, use, and protect your information when you use our scheduling
+          platform at tinycal.zenithstudio.app (the &quot;Service&quot;).
+        </p>
+
+        <h2>1. Information We Collect</h2>
+
+        <h3>Account Information</h3>
+        <p>When you create an account, we collect your name, email address, and profile image through your authentication provider (e.g., Google, Amazon Cognito).</p>
+
+        <h3>Calendar Data</h3>
+        <p>
+          When you connect a calendar (Google Calendar or Outlook), we access your calendar&apos;s
+          free/busy information and event details solely to check availability and create meeting
+          events on your behalf. We store OAuth tokens securely to maintain this connection.
+        </p>
+
+        <h3>Booking Data</h3>
+        <p>
+          When someone books a meeting with you, we collect the booker&apos;s name, email address,
+          phone number (if provided), timezone, and any answers to custom questions you&apos;ve configured.
+        </p>
+
+        <h3>Meeting Link Data</h3>
+        <p>
+          When you create a shareable meeting link, we may collect the recipient&apos;s name, email,
+          phone number, and LinkedIn profile if they choose to provide them during confirmation.
+        </p>
+
+        <h3>Usage Data</h3>
+        <p>We automatically collect standard server logs including IP addresses, browser type, and pages visited to maintain and improve the Service.</p>
+
+        <h2>2. How We Use Your Information</h2>
+        <ul>
+          <li>To provide scheduling and calendar integration functionality</li>
+          <li>To create and manage bookings and meeting links</li>
+          <li>To send booking confirmation, reminder, and notification emails</li>
+          <li>To check calendar availability and prevent double-bookings</li>
+          <li>To create contacts from booking interactions</li>
+          <li>To trigger webhooks you have configured</li>
+          <li>To process payments through Stripe (if applicable)</li>
+          <li>To maintain and improve the Service</li>
+        </ul>
+
+        <h2>3. Google API Services</h2>
+        <p>
+          TinyCal&apos;s use and transfer of information received from Google APIs adheres to the{" "}
+          <a href="https://developers.google.com/terms/api-services-user-data-policy" target="_blank" rel="noopener noreferrer">
+            Google API Services User Data Policy
+          </a>, including the Limited Use requirements. Specifically:
+        </p>
+        <ul>
+          <li>We only access Google Calendar data necessary to provide scheduling functionality</li>
+          <li>We do not use Google Calendar data for advertising purposes</li>
+          <li>We do not sell Google Calendar data to third parties</li>
+          <li>Calendar data is only shared with meeting participants as part of the booking flow</li>
+        </ul>
+
+        <h2>4. Data Sharing</h2>
+        <p>We do not sell your personal information. We share data only in the following cases:</p>
+        <ul>
+          <li><strong>Meeting participants:</strong> Booking details are shared between the host and the person booking (name, email, meeting time, meeting URL)</li>
+          <li><strong>Calendar providers:</strong> Event details are sent to Google Calendar or Outlook to create calendar events</li>
+          <li><strong>Payment processing:</strong> If you use paid bookings, payment information is processed by Stripe</li>
+          <li><strong>Webhooks:</strong> If you configure webhooks, booking data is sent to URLs you specify</li>
+          <li><strong>Email delivery:</strong> We use email services to send booking notifications</li>
+        </ul>
+
+        <h2>5. Data Storage and Security</h2>
+        <p>
+          Your data is stored in secure, encrypted databases hosted on Neon (PostgreSQL). OAuth tokens
+          are stored encrypted. We use HTTPS for all data transmission. The Service is hosted on
+          AWS Amplify / Vercel with industry-standard security measures.
+        </p>
+
+        <h2>6. Data Retention</h2>
+        <p>
+          We retain your account data and booking history for as long as your account is active.
+          You can request deletion of your account and associated data at any time by contacting us.
+          Calendar OAuth tokens are retained until you disconnect the calendar or delete your account.
+        </p>
+
+        <h2>7. Your Rights</h2>
+        <p>You have the right to:</p>
+        <ul>
+          <li>Access the personal data we hold about you</li>
+          <li>Request correction of inaccurate data</li>
+          <li>Request deletion of your data</li>
+          <li>Disconnect calendar integrations at any time</li>
+          <li>Export your booking data</li>
+          <li>Revoke Google Calendar access through your <a href="https://myaccount.google.com/permissions" target="_blank" rel="noopener noreferrer">Google Account permissions</a></li>
+        </ul>
+
+        <h2>8. Cookies</h2>
+        <p>
+          We use essential cookies for authentication and session management. We do not use
+          third-party tracking or advertising cookies.
+        </p>
+
+        <h2>9. Changes to This Policy</h2>
+        <p>
+          We may update this Privacy Policy from time to time. We will notify you of significant
+          changes by posting a notice on the Service.
+        </p>
+
+        <h2>10. Contact Us</h2>
+        <p>
+          If you have questions about this Privacy Policy or wish to exercise your data rights,
+          contact us at:
+        </p>
+        <ul>
+          <li>Email: support@zenithstudio.io</li>
+          <li>Website: <a href="https://tinycal.zenithstudio.app">tinycal.zenithstudio.app</a></li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,161 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Terms of Service - TinyCal",
+}
+
+export default function TermsOfService() {
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50">
+        <div className="max-w-4xl mx-auto px-6 h-16 flex items-center">
+          <Link href="/" className="text-xl font-bold text-blue-600">
+            Tiny<span className="text-gray-900">Cal</span>
+          </Link>
+        </div>
+      </nav>
+
+      <div className="max-w-3xl mx-auto px-6 py-16 prose prose-gray">
+        <h1>Terms of Service</h1>
+        <p className="text-gray-500">Last updated: April 1, 2026</p>
+
+        <p>
+          These Terms of Service (&quot;Terms&quot;) govern your use of TinyCal, a scheduling platform
+          operated by Zenith Studio (&quot;we&quot;, &quot;our&quot;, or &quot;us&quot;), accessible at
+          tinycal.zenithstudio.app (the &quot;Service&quot;).
+        </p>
+        <p>By using the Service, you agree to these Terms. If you do not agree, do not use the Service.</p>
+
+        <h2>1. Description of Service</h2>
+        <p>
+          TinyCal is an online scheduling platform that allows users to create booking pages, manage
+          event types, share meeting links, and integrate with third-party calendar and video
+          conferencing services. The Service includes free and paid tiers.
+        </p>
+
+        <h2>2. Account Registration</h2>
+        <ul>
+          <li>You must provide accurate information when creating an account</li>
+          <li>You are responsible for maintaining the security of your account credentials</li>
+          <li>You must be at least 18 years old or the age of majority in your jurisdiction</li>
+          <li>One person may not maintain more than one free account</li>
+        </ul>
+
+        <h2>3. Acceptable Use</h2>
+        <p>You agree not to:</p>
+        <ul>
+          <li>Use the Service for any unlawful purpose</li>
+          <li>Send spam or unsolicited communications through the Service</li>
+          <li>Attempt to gain unauthorized access to other users&apos; accounts or data</li>
+          <li>Interfere with or disrupt the Service&apos;s infrastructure</li>
+          <li>Use the Service to collect personal information without consent</li>
+          <li>Resell or redistribute the Service without authorization</li>
+          <li>Use automated means to access the Service beyond normal API usage</li>
+        </ul>
+
+        <h2>4. Calendar and Third-Party Integrations</h2>
+        <p>
+          The Service integrates with third-party services including Google Calendar, Microsoft
+          Outlook, Zoom, and Stripe. Your use of these integrations is also subject to the
+          respective third-party terms of service. We are not responsible for the availability
+          or functionality of third-party services.
+        </p>
+        <p>
+          You authorize us to access your connected calendar data solely for the purpose of
+          providing scheduling functionality, including checking availability and creating events.
+        </p>
+
+        <h2>5. Meeting Links and Bookings</h2>
+        <p>
+          When you create a meeting link or booking page, you are responsible for the accuracy
+          of the meeting details. Recipients who confirm meetings consent to sharing their
+          provided contact information (name, email, phone, LinkedIn) with you as the meeting host.
+        </p>
+
+        <h2>6. Payments</h2>
+        <p>
+          If you enable paid bookings, payments are processed through Stripe. You are responsible
+          for complying with applicable tax laws and Stripe&apos;s terms of service. We are not
+          responsible for payment disputes between you and your clients.
+        </p>
+
+        <h2>7. Free and Paid Plans</h2>
+        <p>
+          The Service offers a free tier with limited features and paid plans with additional
+          capabilities. We reserve the right to modify plan features and pricing with reasonable
+          notice. Paid subscriptions are billed in advance and are non-refundable except as
+          required by law.
+        </p>
+
+        <h2>8. Data and Content</h2>
+        <p>
+          You retain ownership of any content you submit to the Service (event descriptions,
+          custom questions, notes, etc.). By using the Service, you grant us a limited license
+          to store, process, and display your content as necessary to provide the Service.
+        </p>
+
+        <h2>9. Privacy</h2>
+        <p>
+          Your use of the Service is also governed by our{" "}
+          <Link href="/privacy" className="text-blue-600 hover:underline">Privacy Policy</Link>,
+          which describes how we collect, use, and protect your information.
+        </p>
+
+        <h2>10. Service Availability</h2>
+        <p>
+          We strive to maintain high availability but do not guarantee uninterrupted service.
+          We may perform maintenance or updates that temporarily affect availability. We are
+          not liable for any losses resulting from service interruptions.
+        </p>
+
+        <h2>11. Limitation of Liability</h2>
+        <p>
+          To the maximum extent permitted by law, TinyCal and Zenith Studio shall not be liable
+          for any indirect, incidental, special, consequential, or punitive damages, including
+          loss of profits, data, or business opportunities, arising from your use of the Service.
+        </p>
+        <p>
+          Our total liability for any claim arising from the Service shall not exceed the amount
+          you paid us in the 12 months preceding the claim, or $100, whichever is greater.
+        </p>
+
+        <h2>12. Disclaimer of Warranties</h2>
+        <p>
+          The Service is provided &quot;as is&quot; and &quot;as available&quot; without warranties of any kind,
+          either express or implied, including but not limited to warranties of merchantability,
+          fitness for a particular purpose, or non-infringement.
+        </p>
+
+        <h2>13. Termination</h2>
+        <p>
+          You may stop using the Service and delete your account at any time. We may suspend
+          or terminate your account if you violate these Terms or for any other reason with
+          reasonable notice. Upon termination, your right to use the Service ceases and we
+          may delete your data after a reasonable retention period.
+        </p>
+
+        <h2>14. Changes to These Terms</h2>
+        <p>
+          We may update these Terms from time to time. We will notify you of material changes
+          by posting a notice on the Service. Continued use of the Service after changes
+          constitutes acceptance of the updated Terms.
+        </p>
+
+        <h2>15. Governing Law</h2>
+        <p>
+          These Terms are governed by the laws of the jurisdiction in which Zenith Studio
+          operates, without regard to conflict of law provisions.
+        </p>
+
+        <h2>16. Contact Us</h2>
+        <p>
+          If you have questions about these Terms, contact us at:
+        </p>
+        <ul>
+          <li>Email: support@zenithstudio.io</li>
+          <li>Website: <a href="https://tinycal.zenithstudio.app">tinycal.zenithstudio.app</a></li>
+        </ul>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Implements /privacy and /terms pages as required for Google OAuth verification.

## Changes
- Added Privacy Policy at `/privacy`
- Added Terms of Service at `/terms`
- Both pages include navigation back to homepage
- Already linked from landing page footer

## Details
- Privacy policy covers data collection, usage, storage, and user rights
- Terms of service outlines acceptable use, integrations, and liability
- Both pages comply with Google API Services User Data Policy requirements

Closes #28