### PR TITLE
TD-0042: Availability Schedules Per Event Type

### DIFF
--- a/prisma/migrations/20260408000000_add_availability_schedules/migration.sql
+++ b/prisma/migrations/20260408000000_add_availability_schedules/migration.sql
@@ -1,0 +1,113 @@
+-- Idempotent: this migration was retried in preview environments where some
+-- tables/columns/constraints already existed. Each statement is guarded so the
+-- migration can be applied to a partially-populated database without erroring.
+
+-- CreateTable: AvailabilitySchedule
+CREATE TABLE IF NOT EXISTS "AvailabilitySchedule" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AvailabilitySchedule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: AvailabilityRule
+CREATE TABLE IF NOT EXISTS "AvailabilityRule" (
+    "id" TEXT NOT NULL,
+    "availabilityScheduleId" TEXT NOT NULL,
+    "dayOfWeek" INTEGER,
+    "date" TIMESTAMP(3),
+    "startTime" TEXT NOT NULL,
+    "endTime" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "AvailabilityRule_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable: EventType
+ALTER TABLE "EventType" ADD COLUMN IF NOT EXISTS "availabilityScheduleId" TEXT;
+
+-- AlterTable: User
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "defaultAvailabilityScheduleId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "AvailabilitySchedule_userId_name_key" ON "AvailabilitySchedule"("userId", "name");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "AvailabilitySchedule_userId_isDefault_idx" ON "AvailabilitySchedule"("userId", "isDefault");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "AvailabilityRule_availabilityScheduleId_dayOfWeek_date_key" ON "AvailabilityRule"("availabilityScheduleId", "dayOfWeek", "date");
+
+-- Unique constraint on User.defaultAvailabilityScheduleId — Postgres has no
+-- ADD CONSTRAINT IF NOT EXISTS, so guard via catalog lookup.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'User_defaultAvailabilityScheduleId_key'
+    ) THEN
+        ALTER TABLE "User"
+            ADD CONSTRAINT "User_defaultAvailabilityScheduleId_key"
+            UNIQUE ("defaultAvailabilityScheduleId");
+    END IF;
+END$$;
+
+-- AddForeignKey: AvailabilitySchedule.userId -> User.id
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'AvailabilitySchedule_userId_fkey'
+    ) THEN
+        ALTER TABLE "AvailabilitySchedule"
+            ADD CONSTRAINT "AvailabilitySchedule_userId_fkey"
+            FOREIGN KEY ("userId") REFERENCES "User"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END$$;
+
+-- AddForeignKey: AvailabilityRule.availabilityScheduleId -> AvailabilitySchedule.id
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'AvailabilityRule_availabilityScheduleId_fkey'
+    ) THEN
+        ALTER TABLE "AvailabilityRule"
+            ADD CONSTRAINT "AvailabilityRule_availabilityScheduleId_fkey"
+            FOREIGN KEY ("availabilityScheduleId") REFERENCES "AvailabilitySchedule"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END$$;
+
+-- AddForeignKey: EventType.availabilityScheduleId -> AvailabilitySchedule.id
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'EventType_availabilityScheduleId_fkey'
+    ) THEN
+        ALTER TABLE "EventType"
+            ADD CONSTRAINT "EventType_availabilityScheduleId_fkey"
+            FOREIGN KEY ("availabilityScheduleId") REFERENCES "AvailabilitySchedule"("id")
+            ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END$$;
+
+-- AddForeignKey: User.defaultAvailabilityScheduleId -> AvailabilitySchedule.id
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'User_defaultAvailabilityScheduleId_fkey'
+    ) THEN
+        ALTER TABLE "User"
+            ADD CONSTRAINT "User_defaultAvailabilityScheduleId_fkey"
+            FOREIGN KEY ("defaultAvailabilityScheduleId") REFERENCES "AvailabilitySchedule"("id")
+            ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,9 @@ model User {
   brandColor    String   @default("#2563eb")
   brandLogo     String?
   slug          String?  @unique
+  
+  // Default availability schedule
+  defaultAvailabilityScheduleId String? @unique
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -36,16 +39,55 @@ model User {
   eventTypes     EventType[]
   bookings       Booking[]
   availability   Availability[]
+  availabilitySchedules AvailabilitySchedule[]
   calendarConnections CalendarConnection[]
   webhooks       Webhook[]
   contacts       Contact[]
   documents      Document[]
   apiKeys        ApiKey[]
+  defaultAvailabilitySchedule AvailabilitySchedule? @relation("defaultSchedule", fields: [defaultAvailabilityScheduleId], references: [id])
 }
 
 enum Plan {
   FREE
   PRO
+}
+
+// ─── Availability Schedules ───
+
+model AvailabilitySchedule {
+  id            String  @id @default(cuid())
+  userId        String
+  name          String
+  isDefault     Boolean @default(false)
+  
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user       User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rules      AvailabilityRule[]
+  eventTypes EventType[]
+  defaultForUser User? @relation("defaultSchedule")
+
+  @@unique([userId, name])
+  @@index([userId, isDefault])
+}
+
+model AvailabilityRule {
+  id                    String  @id @default(cuid())
+  availabilityScheduleId String
+  
+  // Day of week (0=Sunday, 6=Saturday) or specific date
+  dayOfWeek Int?      // 0-6
+  date      DateTime? // for date-specific overrides
+  
+  startTime String // "09:00"
+  endTime   String // "17:00"
+  enabled   Boolean @default(true)
+
+  schedule AvailabilitySchedule @relation(fields: [availabilityScheduleId], references: [id], onDelete: Cascade)
+  
+  @@unique([availabilityScheduleId, dayOfWeek, date])
 }
 
 // ─── Scheduling: Event Types ───
@@ -78,6 +120,9 @@ model EventType {
   // Collective scheduling
   isCollective   Boolean @default(false)
   collectiveMembers String[] // user IDs
+  
+  // Availability Schedule
+  availabilityScheduleId String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -85,6 +130,7 @@ model EventType {
   user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   bookings  Booking[]
   questions CustomQuestion[]
+  availabilitySchedule AvailabilitySchedule? @relation(fields: [availabilityScheduleId], references: [id], onDelete: SetNull)
 
   @@unique([userId, slug])
 }

--- a/src/__tests__/api/availability-schedules.test.ts
+++ b/src/__tests__/api/availability-schedules.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// ─── Mock Data ───
+
+const TEST_USER = {
+  id: "user-123",
+  name: "Alice",
+  email: "alice@example.com",
+  timezone: "America/New_York",
+  plan: "FREE",
+  defaultAvailabilityScheduleId: null,
+}
+
+const TEST_SCHEDULE = {
+  id: "sched-123",
+  userId: TEST_USER.id,
+  name: "Work Hours",
+  isDefault: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const TEST_RULES = [
+  {
+    id: "rule-1",
+    availabilityScheduleId: TEST_SCHEDULE.id,
+    dayOfWeek: 1,
+    date: null,
+    startTime: "09:00",
+    endTime: "17:00",
+    enabled: true,
+  },
+  {
+    id: "rule-2",
+    availabilityScheduleId: TEST_SCHEDULE.id,
+    dayOfWeek: 5,
+    date: null,
+    startTime: "09:00",
+    endTime: "12:00",
+    enabled: true,
+  },
+]
+
+// ─── Mocks ───
+
+const mockGetAuthenticatedUser = vi.fn()
+const mockPrisma = {
+  availabilitySchedule: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    delete: vi.fn(),
+  },
+  availabilityRule: {
+    createMany: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  eventType: {
+    count: vi.fn(),
+  },
+  user: {
+    update: vi.fn(),
+  },
+}
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: (...args: any[]) => mockGetAuthenticatedUser(...args),
+}))
+
+vi.mock("@/lib/prisma", () => ({
+  default: mockPrisma,
+}))
+
+// ─── Helpers ───
+
+function makeRequest(body: any, method: string = "POST"): Request {
+  return new Request("http://localhost/api/availability/schedules", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeIdRequest(id: string, body: any, method: string = "GET"): Request {
+  return new Request(`http://localhost/api/availability/schedules/${id}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    ...(method !== "GET" && { body: JSON.stringify(body) }),
+  })
+}
+
+// ─── Setup ───
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetAuthenticatedUser.mockResolvedValue(TEST_USER)
+  mockPrisma.availabilitySchedule.create.mockResolvedValue({
+    ...TEST_SCHEDULE,
+    rules: TEST_RULES,
+  })
+  mockPrisma.availabilitySchedule.findMany.mockResolvedValue([
+    { ...TEST_SCHEDULE, rules: TEST_RULES },
+  ])
+  mockPrisma.availabilitySchedule.findFirst.mockResolvedValue({
+    ...TEST_SCHEDULE,
+    rules: TEST_RULES,
+  })
+  mockPrisma.availabilitySchedule.findUnique.mockResolvedValue({
+    ...TEST_SCHEDULE,
+    rules: TEST_RULES,
+  })
+  mockPrisma.availabilitySchedule.update.mockResolvedValue({
+    ...TEST_SCHEDULE,
+    rules: TEST_RULES,
+  })
+  mockPrisma.availabilityRule.deleteMany.mockResolvedValue({ count: 2 })
+  mockPrisma.availabilityRule.createMany.mockResolvedValue({ count: 2 })
+  mockPrisma.eventType.count.mockResolvedValue(0)
+  mockPrisma.user.update.mockResolvedValue({ ...TEST_USER, defaultAvailabilityScheduleId: TEST_SCHEDULE.id })
+})
+
+// ─── Tests ───
+
+describe("POST /api/availability/schedules", () => {
+  let handler: typeof import("@/app/api/availability/schedules/route")
+
+  beforeEach(async () => {
+    handler = await import("@/app/api/availability/schedules/route")
+  })
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(null)
+    const res = await handler.POST(makeRequest({ name: "Work Hours" }))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 400 when name is missing", async () => {
+    const res = await handler.POST(makeRequest({}))
+    expect(res.status).toBe(400)
+  })
+
+  it("creates a schedule with name and rules", async () => {
+    const res = await handler.POST(
+      makeRequest({
+        name: "Work Hours",
+        rules: [
+          { dayOfWeek: 1, startTime: "09:00", endTime: "17:00" },
+        ],
+      })
+    )
+
+    expect(res.status).toBe(201)
+    expect(mockPrisma.availabilitySchedule.create).toHaveBeenCalled()
+  })
+
+  it("sets schedule as default", async () => {
+    const res = await handler.POST(
+      makeRequest({
+        name: "Work Hours",
+        isDefault: true,
+        rules: [{ dayOfWeek: 1, startTime: "09:00", endTime: "17:00" }],
+      })
+    )
+
+    expect(res.status).toBe(201)
+    expect(mockPrisma.availabilitySchedule.updateMany).toHaveBeenCalled()
+    expect(mockPrisma.user.update).toHaveBeenCalled()
+  })
+})
+
+describe("GET /api/availability/schedules", () => {
+  let handler: typeof import("@/app/api/availability/schedules/route")
+
+  beforeEach(async () => {
+    handler = await import("@/app/api/availability/schedules/route")
+  })
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(null)
+    const res = await handler.GET()
+    expect(res.status).toBe(401)
+  })
+
+  it("returns all schedules for user", async () => {
+    const res = await handler.GET()
+    expect(res.status).toBe(200)
+    expect(mockPrisma.availabilitySchedule.findMany).toHaveBeenCalled()
+  })
+})
+
+describe("GET /api/availability/schedules/[id]", () => {
+  let handler: typeof import("@/app/api/availability/schedules/[id]/route")
+
+  beforeEach(async () => {
+    handler = await import("@/app/api/availability/schedules/[id]/route")
+  })
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(null)
+    const res = await handler.GET(
+      makeIdRequest("sched-123", null),
+      { params: { id: "sched-123" } }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 404 when schedule not found", async () => {
+    mockPrisma.availabilitySchedule.findFirst.mockResolvedValue(null)
+    const res = await handler.GET(
+      makeIdRequest("sched-999", null),
+      { params: { id: "sched-999" } }
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("returns schedule for valid id", async () => {
+    const res = await handler.GET(
+      makeIdRequest("sched-123", null),
+      { params: { id: "sched-123" } }
+    )
+    expect(res.status).toBe(200)
+  })
+})
+
+describe("PUT /api/availability/schedules/[id]", () => {
+  let handler: typeof import("@/app/api/availability/schedules/[id]/route")
+
+  beforeEach(async () => {
+    handler = await import("@/app/api/availability/schedules/[id]/route")
+  })
+
+  it("updates schedule name", async () => {
+    const res = await handler.PUT(
+      makeIdRequest("sched-123", { name: "Updated" }, "PUT"),
+      { params: { id: "sched-123" } }
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockPrisma.availabilitySchedule.update).toHaveBeenCalled()
+  })
+
+  it("returns 404 when schedule not found", async () => {
+    mockPrisma.availabilitySchedule.findFirst.mockResolvedValue(null)
+    const res = await handler.PUT(
+      makeIdRequest("sched-999", { name: "Updated" }, "PUT"),
+      { params: { id: "sched-999" } }
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("DELETE /api/availability/schedules/[id]", () => {
+  let handler: typeof import("@/app/api/availability/schedules/[id]/route")
+
+  beforeEach(async () => {
+    handler = await import("@/app/api/availability/schedules/[id]/route")
+  })
+
+  it("returns 404 when schedule not found", async () => {
+    mockPrisma.availabilitySchedule.findFirst.mockResolvedValue(null)
+    const res = await handler.DELETE(
+      makeIdRequest("sched-999", null, "DELETE"),
+      { params: { id: "sched-999" } }
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 400 when schedule linked to event types", async () => {
+    mockPrisma.eventType.count.mockResolvedValue(2)
+
+    const res = await handler.DELETE(
+      makeIdRequest("sched-123", null, "DELETE"),
+      { params: { id: "sched-123" } }
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  it("deletes schedule", async () => {
+    const res = await handler.DELETE(
+      makeIdRequest("sched-123", null, "DELETE"),
+      { params: { id: "sched-123" } }
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockPrisma.availabilitySchedule.delete).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/api/availability-schedules.test.ts
+++ b/src/__tests__/api/availability-schedules.test.ts
@@ -44,7 +44,7 @@ const TEST_RULES = [
 // ─── Mocks ───
 
 const mockGetAuthenticatedUser = vi.fn()
-const mockPrisma = {
+const mockPrisma: any = {
   availabilitySchedule: {
     findMany: vi.fn(),
     findFirst: vi.fn(),
@@ -64,6 +64,10 @@ const mockPrisma = {
   user: {
     update: vi.fn(),
   },
+  // Routes wrap multi-step writes in a single transaction. The interactive
+  // form `prisma.$transaction(async tx => …)` is what we mock; tx mirrors the
+  // top-level client so the callbacks compose without rewriting them per test.
+  $transaction: vi.fn((fn: any) => (typeof fn === "function" ? fn(mockPrisma) : Promise.all(fn))),
 }
 
 vi.mock("@/lib/auth", () => ({

--- a/src/app/api/availability/schedules/[id]/route.ts
+++ b/src/app/api/availability/schedules/[id]/route.ts
@@ -1,0 +1,180 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const schedule = await prisma.availabilitySchedule.findFirst({
+    where: { id: params.id, userId: user.id },
+    include: { rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] } },
+  })
+
+  if (!schedule) {
+    return NextResponse.json({ error: "Schedule not found" }, { status: 404 })
+  }
+
+  return NextResponse.json(schedule)
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  try {
+    // Verify ownership
+    const existing = await prisma.availabilitySchedule.findFirst({
+      where: { id: params.id, userId: user.id },
+    })
+
+    if (!existing) {
+      return NextResponse.json({ error: "Schedule not found" }, { status: 404 })
+    }
+
+    const body = await req.json()
+    const { name, isDefault, rules } = body
+
+    if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
+      return NextResponse.json({ error: "Schedule name is required" }, { status: 400 })
+    }
+
+    // Validate rules if provided
+    if (rules && Array.isArray(rules)) {
+      for (const rule of rules) {
+        if (!rule.startTime || !rule.endTime) {
+          return NextResponse.json(
+            { error: "Each rule must have startTime and endTime" },
+            { status: 400 }
+          )
+        }
+      }
+    }
+
+    // If setting as default, unset any previous default
+    if (isDefault && !existing.isDefault) {
+      await prisma.availabilitySchedule.updateMany({
+        where: { userId: user.id, isDefault: true, id: { not: params.id } },
+        data: { isDefault: false },
+      })
+    }
+
+    // Update the schedule
+    await prisma.availabilitySchedule.update({
+      where: { id: params.id },
+      data: {
+        ...(name !== undefined && { name: name.trim() }),
+        ...(isDefault !== undefined && { isDefault }),
+      },
+    })
+
+    // Update rules if provided
+    if (rules !== undefined) {
+      // Delete existing rules
+      await prisma.availabilityRule.deleteMany({
+        where: { availabilityScheduleId: params.id },
+      })
+
+      // Create new rules
+      if (rules.length > 0) {
+        await prisma.availabilityRule.createMany({
+          data: rules.map((r: any) => ({
+            availabilityScheduleId: params.id,
+            dayOfWeek: r.dayOfWeek,
+            date: r.date ? new Date(r.date) : null,
+            startTime: r.startTime,
+            endTime: r.endTime,
+            enabled: r.enabled ?? true,
+          })),
+        })
+      }
+    }
+
+    // Keep User.defaultAvailabilityScheduleId in sync with isDefault. The bug
+    // before: when isDefault and rules were both sent, the early return for
+    // the rules path skipped this update, so the pointer drifted from the
+    // schedule it should point at.
+    if (isDefault === true) {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { defaultAvailabilityScheduleId: params.id },
+      })
+    } else if (isDefault === false && existing.isDefault) {
+      // Clearing the default flag on the currently-default schedule clears
+      // the user pointer too — otherwise the User row keeps a stale ID.
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { defaultAvailabilityScheduleId: null },
+      })
+    }
+
+    const refreshed = await prisma.availabilitySchedule.findUnique({
+      where: { id: params.id },
+      include: { rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] } },
+    })
+
+    return NextResponse.json(refreshed)
+  } catch (error) {
+    console.error("Error updating schedule:", error)
+    return NextResponse.json({ error: "Failed to update schedule" }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  try {
+    // Verify ownership
+    const schedule = await prisma.availabilitySchedule.findFirst({
+      where: { id: params.id, userId: user.id },
+    })
+
+    if (!schedule) {
+      return NextResponse.json({ error: "Schedule not found" }, { status: 404 })
+    }
+
+    // Block deletion if the owner still has event types linked — the error
+    // message tells them to unlink, which they can only do for their own
+    // event types, so scope the count to user.id. Any cross-user link (which
+    // shouldn't exist post #55, but isn't enforced at the DB layer) would
+    // simply be SET NULL by the FK on delete.
+    const linkedEventTypes = await prisma.eventType.count({
+      where: { availabilityScheduleId: params.id, userId: user.id },
+    })
+
+    if (linkedEventTypes > 0) {
+      return NextResponse.json(
+        { error: "Cannot delete schedule linked to event types. Unlink them first." },
+        { status: 400 }
+      )
+    }
+
+    // If this was the default, clear it
+    if (schedule.isDefault) {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { defaultAvailabilityScheduleId: null },
+      })
+    }
+
+    // Delete the schedule (cascade deletes rules)
+    await prisma.availabilitySchedule.delete({
+      where: { id: params.id },
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Error deleting schedule:", error)
+    return NextResponse.json({ error: "Failed to delete schedule" }, { status: 500 })
+  }
+}

--- a/src/app/api/availability/schedules/[id]/route.ts
+++ b/src/app/api/availability/schedules/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { getAuthenticatedUser } from "@/lib/auth"
 import prisma from "@/lib/prisma"
+import { validateRules } from "@/lib/availability-validation"
 
 export async function GET(
   req: Request,
@@ -45,78 +46,65 @@ export async function PUT(
       return NextResponse.json({ error: "Schedule name is required" }, { status: 400 })
     }
 
-    // Validate rules if provided
-    if (rules && Array.isArray(rules)) {
-      for (const rule of rules) {
-        if (!rule.startTime || !rule.endTime) {
-          return NextResponse.json(
-            { error: "Each rule must have startTime and endTime" },
-            { status: 400 }
-          )
-        }
-      }
-    }
-
-    // If setting as default, unset any previous default
-    if (isDefault && !existing.isDefault) {
-      await prisma.availabilitySchedule.updateMany({
-        where: { userId: user.id, isDefault: true, id: { not: params.id } },
-        data: { isDefault: false },
-      })
-    }
-
-    // Update the schedule
-    await prisma.availabilitySchedule.update({
-      where: { id: params.id },
-      data: {
-        ...(name !== undefined && { name: name.trim() }),
-        ...(isDefault !== undefined && { isDefault }),
-      },
-    })
-
-    // Update rules if provided
     if (rules !== undefined) {
-      // Delete existing rules
-      await prisma.availabilityRule.deleteMany({
-        where: { availabilityScheduleId: params.id },
-      })
+      const err = validateRules(rules)
+      if (err) return NextResponse.json({ error: err }, { status: 400 })
+    }
 
-      // Create new rules
-      if (rules.length > 0) {
-        await prisma.availabilityRule.createMany({
-          data: rules.map((r: any) => ({
-            availabilityScheduleId: params.id,
-            dayOfWeek: r.dayOfWeek,
-            date: r.date ? new Date(r.date) : null,
-            startTime: r.startTime,
-            endTime: r.endTime,
-            enabled: r.enabled ?? true,
-          })),
+    // All writes go through one transaction so the schedule fields, rules
+    // replacement, and User.defaultAvailabilityScheduleId pointer can't drift
+    // apart on partial failure.
+    const refreshed = await prisma.$transaction(async (tx) => {
+      if (isDefault && !existing.isDefault) {
+        await tx.availabilitySchedule.updateMany({
+          where: { userId: user.id, isDefault: true, id: { not: params.id } },
+          data: { isDefault: false },
         })
       }
-    }
 
-    // Keep User.defaultAvailabilityScheduleId in sync with isDefault. The bug
-    // before: when isDefault and rules were both sent, the early return for
-    // the rules path skipped this update, so the pointer drifted from the
-    // schedule it should point at.
-    if (isDefault === true) {
-      await prisma.user.update({
-        where: { id: user.id },
-        data: { defaultAvailabilityScheduleId: params.id },
+      await tx.availabilitySchedule.update({
+        where: { id: params.id },
+        data: {
+          ...(name !== undefined && { name: name.trim() }),
+          ...(isDefault !== undefined && { isDefault }),
+        },
       })
-    } else if (isDefault === false && existing.isDefault) {
-      // Clearing the default flag on the currently-default schedule clears
-      // the user pointer too — otherwise the User row keeps a stale ID.
-      await prisma.user.update({
-        where: { id: user.id },
-        data: { defaultAvailabilityScheduleId: null },
-      })
-    }
 
-    const refreshed = await prisma.availabilitySchedule.findUnique({
-      where: { id: params.id },
-      include: { rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] } },
+      if (rules !== undefined) {
+        await tx.availabilityRule.deleteMany({
+          where: { availabilityScheduleId: params.id },
+        })
+        if (rules.length > 0) {
+          await tx.availabilityRule.createMany({
+            data: rules.map((r: any) => ({
+              availabilityScheduleId: params.id,
+              dayOfWeek: r.dayOfWeek,
+              date: r.date ? new Date(r.date) : null,
+              startTime: r.startTime,
+              endTime: r.endTime,
+              enabled: r.enabled ?? true,
+            })),
+          })
+        }
+      }
+
+      // Keep User.defaultAvailabilityScheduleId in sync with isDefault.
+      if (isDefault === true) {
+        await tx.user.update({
+          where: { id: user.id },
+          data: { defaultAvailabilityScheduleId: params.id },
+        })
+      } else if (isDefault === false && existing.isDefault) {
+        await tx.user.update({
+          where: { id: user.id },
+          data: { defaultAvailabilityScheduleId: null },
+        })
+      }
+
+      return tx.availabilitySchedule.findUnique({
+        where: { id: params.id },
+        include: { rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] } },
+      })
     })
 
     return NextResponse.json(refreshed)

--- a/src/app/api/availability/schedules/route.ts
+++ b/src/app/api/availability/schedules/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+export async function GET() {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const schedules = await prisma.availabilitySchedule.findMany({
+    where: { userId: user.id },
+    include: { rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] } },
+    orderBy: { createdAt: "desc" },
+  })
+  return NextResponse.json(schedules)
+}
+
+export async function POST(req: Request) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  try {
+    const body = await req.json()
+    const { name, isDefault, rules } = body
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      return NextResponse.json({ error: "Schedule name is required" }, { status: 400 })
+    }
+
+    // Validate rules if provided
+    if (rules && Array.isArray(rules)) {
+      for (const rule of rules) {
+        if (!rule.startTime || !rule.endTime) {
+          return NextResponse.json(
+            { error: "Each rule must have startTime and endTime" },
+            { status: 400 }
+          )
+        }
+      }
+    }
+
+    // If setting as default, unset any previous default
+    if (isDefault) {
+      await prisma.availabilitySchedule.updateMany({
+        where: { userId: user.id, isDefault: true },
+        data: { isDefault: false },
+      })
+    }
+
+    const schedule = await prisma.availabilitySchedule.create({
+      data: {
+        userId: user.id,
+        name: name.trim(),
+        isDefault: isDefault || false,
+        rules: rules?.length
+          ? {
+              create: rules.map((r: any) => ({
+                dayOfWeek: r.dayOfWeek,
+                date: r.date ? new Date(r.date) : null,
+                startTime: r.startTime,
+                endTime: r.endTime,
+                enabled: r.enabled ?? true,
+              })),
+            }
+          : undefined,
+      },
+      include: { rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] } },
+    })
+
+    // If set as default, update user
+    if (isDefault) {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { defaultAvailabilityScheduleId: schedule.id },
+      })
+    }
+
+    return NextResponse.json(schedule, { status: 201 })
+  } catch (error) {
+    console.error("Error creating schedule:", error)
+    return NextResponse.json({ error: "Failed to create schedule" }, { status: 500 })
+  }
+}

--- a/src/app/api/availability/schedules/route.ts
+++ b/src/app/api/availability/schedules/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { getAuthenticatedUser } from "@/lib/auth"
 import prisma from "@/lib/prisma"
+import { validateRules } from "@/lib/availability-validation"
 
 export async function GET() {
   const user = await getAuthenticatedUser()
@@ -26,53 +27,47 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Schedule name is required" }, { status: 400 })
     }
 
-    // Validate rules if provided
-    if (rules && Array.isArray(rules)) {
-      for (const rule of rules) {
-        if (!rule.startTime || !rule.endTime) {
-          return NextResponse.json(
-            { error: "Each rule must have startTime and endTime" },
-            { status: 400 }
-          )
-        }
+    if (rules !== undefined) {
+      const err = validateRules(rules)
+      if (err) return NextResponse.json({ error: err }, { status: 400 })
+    }
+
+    // The unset-default → create → update-pointer trio is wrapped in a
+    // transaction so a partial failure can't leave the user with no default.
+    const schedule = await prisma.$transaction(async (tx) => {
+      if (isDefault) {
+        await tx.availabilitySchedule.updateMany({
+          where: { userId: user.id, isDefault: true },
+          data: { isDefault: false },
+        })
       }
-    }
-
-    // If setting as default, unset any previous default
-    if (isDefault) {
-      await prisma.availabilitySchedule.updateMany({
-        where: { userId: user.id, isDefault: true },
-        data: { isDefault: false },
+      const created = await tx.availabilitySchedule.create({
+        data: {
+          userId: user.id,
+          name: name.trim(),
+          isDefault: isDefault || false,
+          rules: rules?.length
+            ? {
+                create: rules.map((r: any) => ({
+                  dayOfWeek: r.dayOfWeek,
+                  date: r.date ? new Date(r.date) : null,
+                  startTime: r.startTime,
+                  endTime: r.endTime,
+                  enabled: r.enabled ?? true,
+                })),
+              }
+            : undefined,
+        },
+        include: { rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] } },
       })
-    }
-
-    const schedule = await prisma.availabilitySchedule.create({
-      data: {
-        userId: user.id,
-        name: name.trim(),
-        isDefault: isDefault || false,
-        rules: rules?.length
-          ? {
-              create: rules.map((r: any) => ({
-                dayOfWeek: r.dayOfWeek,
-                date: r.date ? new Date(r.date) : null,
-                startTime: r.startTime,
-                endTime: r.endTime,
-                enabled: r.enabled ?? true,
-              })),
-            }
-          : undefined,
-      },
-      include: { rules: { orderBy: [{ dayOfWeek: "asc" }, { startTime: "asc" }] } },
+      if (isDefault) {
+        await tx.user.update({
+          where: { id: user.id },
+          data: { defaultAvailabilityScheduleId: created.id },
+        })
+      }
+      return created
     })
-
-    // If set as default, update user
-    if (isDefault) {
-      await prisma.user.update({
-        where: { id: user.id },
-        data: { defaultAvailabilityScheduleId: schedule.id },
-      })
-    }
 
     return NextResponse.json(schedule, { status: 201 })
   } catch (error) {

--- a/src/app/api/event-types/[id]/route.ts
+++ b/src/app/api/event-types/[id]/route.ts
@@ -79,6 +79,19 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     }
   }
 
+  if (body.availabilityScheduleId) {
+    const schedule = await prisma.availabilitySchedule.findFirst({
+      where: { id: body.availabilityScheduleId, userId: user.id },
+      select: { id: true },
+    })
+    if (!schedule) {
+      return NextResponse.json(
+        { error: "Availability schedule not found" },
+        { status: 404 }
+      )
+    }
+  }
+
   try {
     const eventType = await prisma.eventType.update({
       where: { id: params.id },
@@ -101,7 +114,9 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
         price: body.price,
         isCollective: body.isCollective,
         collectiveMembers: body.collectiveMembers,
+        availabilityScheduleId: body.availabilityScheduleId,
       },
+      include: { questions: { orderBy: { order: "asc" } } },
     })
     return NextResponse.json(eventType)
   } catch (e) {

--- a/src/app/api/event-types/route.ts
+++ b/src/app/api/event-types/route.ts
@@ -30,6 +30,22 @@ export async function POST(req: Request) {
     }
   }
 
+  // Ownership check for the optional availability-schedule pointer — without
+  // this a user could link their event type to someone else's schedule, which
+  // would leak that user's hours via the booking page.
+  if (body.availabilityScheduleId) {
+    const schedule = await prisma.availabilitySchedule.findFirst({
+      where: { id: body.availabilityScheduleId, userId },
+      select: { id: true },
+    })
+    if (!schedule) {
+      return NextResponse.json(
+        { error: "availabilityScheduleId does not resolve to a schedule you own" },
+        { status: 400 }
+      )
+    }
+  }
+
   const slug = generateSlug(body.title)
   const eventType = await prisma.eventType.create({
     data: {
@@ -52,6 +68,7 @@ export async function POST(req: Request) {
       currency: body.currency || "usd",
       isCollective: body.isCollective || false,
       collectiveMembers: body.collectiveMembers || [],
+      availabilityScheduleId: body.availabilityScheduleId,
       questions: body.questions?.length ? {
         create: body.questions.map((q: any, i: number) => ({
           label: q.label,

--- a/src/app/dashboard/event-types/[id]/page.tsx
+++ b/src/app/dashboard/event-types/[id]/page.tsx
@@ -11,6 +11,12 @@ interface CoHost {
   email: string | null
 }
 
+interface Schedule {
+  id: string
+  name: string
+  isDefault: boolean
+}
+
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 function validateSlug(s: string): string | null {
@@ -28,6 +34,7 @@ export default function EditEventTypePage() {
   const [et, setEt] = useState<any>(null)
   const [originalSlug, setOriginalSlug] = useState<string>("")
   const [userSlug, setUserSlug] = useState<string>("")
+  const [schedules, setSchedules] = useState<Schedule[]>([])
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
 
@@ -41,6 +48,7 @@ export default function EditEventTypePage() {
       setOriginalSlug(data.slug ?? "")
     })
     fetch("/api/user").then(r => r.json()).then(u => setUserSlug(u?.slug ?? ""))
+    fetch("/api/availability/schedules").then(r => r.json()).then(setSchedules)
   }, [params.id])
 
   const slugError = et?.slug != null ? validateSlug(et.slug) : null
@@ -202,7 +210,27 @@ export default function EditEventTypePage() {
         </div>
 
         <hr />
-        <h3 className="font-semibold">Scheduling Rules</h3>
+        <h3 className="font-semibold">Availability & Scheduling</h3>
+        <div>
+          <label className="block text-sm font-medium mb-1">Availability Schedule</label>
+          <select
+            value={et.availabilityScheduleId || ""}
+            onChange={e => setEt({ ...et, availabilityScheduleId: e.target.value || null })}
+            className="w-full border rounded-lg px-3 py-2"
+          >
+            <option value="">Use user default schedule</option>
+            {schedules.map(s => (
+              <option key={s.id} value={s.id}>
+                {s.name} {s.isDefault ? "(default)" : ""}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500 mt-1">
+            Event type schedules override user defaults.
+          </p>
+        </div>
+
+        <h3 className="font-semibold mt-4">Scheduling Rules</h3>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
             <label className="block text-sm font-medium mb-1">Buffer before (min)</label>

--- a/src/app/dashboard/schedules/page.tsx
+++ b/src/app/dashboard/schedules/page.tsx
@@ -1,0 +1,194 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Plus, Trash2, Star } from "lucide-react"
+
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+interface Rule {
+  id?: string
+  dayOfWeek?: number
+  date?: string
+  startTime: string
+  endTime: string
+  enabled: boolean
+}
+
+interface Schedule {
+  id: string
+  name: string
+  isDefault: boolean
+  rules: Rule[]
+}
+
+export default function SchedulesPage() {
+  const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [newSchedule, setNewSchedule] = useState({ name: "", rules: [] as Rule[] })
+
+  useEffect(() => {
+    fetchSchedules()
+  }, [])
+
+  async function fetchSchedules() {
+    setLoading(true)
+    const res = await fetch("/api/availability/schedules")
+    const data = await res.json()
+    setSchedules(data || [])
+    setLoading(false)
+  }
+
+  async function handleCreateSchedule() {
+    if (!newSchedule.name.trim()) return
+
+    const res = await fetch("/api/availability/schedules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: newSchedule.name,
+        rules: newSchedule.rules,
+      }),
+    })
+
+    if (res.ok) {
+      await fetchSchedules()
+      setCreating(false)
+      setNewSchedule({ name: "", rules: [] })
+    }
+  }
+
+  async function handleDeleteSchedule(id: string) {
+    if (!confirm("Delete this schedule?")) return
+
+    const res = await fetch(`/api/availability/schedules/${id}`, {
+      method: "DELETE",
+    })
+
+    if (res.ok) {
+      await fetchSchedules()
+    } else {
+      const error = await res.json()
+      alert(error.error || "Failed to delete")
+    }
+  }
+
+  async function handleSetDefault(id: string) {
+    const res = await fetch(`/api/availability/schedules/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ isDefault: true }),
+    })
+
+    if (res.ok) {
+      await fetchSchedules()
+    }
+  }
+
+  if (loading) {
+    return <div className="text-center py-12">Loading schedules...</div>
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Availability Schedules</h1>
+        <button
+          onClick={() => setCreating(true)}
+          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 flex items-center gap-2 text-sm"
+        >
+          <Plus className="w-4 h-4" /> New Schedule
+        </button>
+      </div>
+
+      {creating && (
+        <div className="bg-white border rounded-xl p-6 mb-6">
+          <h2 className="text-lg font-semibold mb-4">Create New Schedule</h2>
+          <div className="space-y-4">
+            <input
+              type="text"
+              placeholder="Schedule name"
+              value={newSchedule.name}
+              onChange={e => setNewSchedule({ ...newSchedule, name: e.target.value })}
+              className="w-full border rounded px-3 py-2 text-sm"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={handleCreateSchedule}
+                className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm"
+              >
+                Create
+              </button>
+              <button
+                onClick={() => setCreating(false)}
+                className="bg-gray-200 text-gray-700 px-4 py-2 rounded hover:bg-gray-300 text-sm"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-4">
+        {schedules.length === 0 ? (
+          <div className="bg-white border rounded-xl p-12 text-center text-gray-500">
+            No schedules yet. Create one to get started.
+          </div>
+        ) : (
+          schedules.map(schedule => (
+            <div key={schedule.id} className="bg-white border rounded-xl p-6">
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-3">
+                  <h3 className="text-lg font-semibold">{schedule.name}</h3>
+                  {schedule.isDefault && (
+                    <span className="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2 py-1 rounded flex items-center gap-1">
+                      <Star className="w-3 h-3" /> Default
+                    </span>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  {!schedule.isDefault && (
+                    <button
+                      onClick={() => handleSetDefault(schedule.id)}
+                      className="text-gray-600 hover:text-blue-600 text-sm px-3 py-1 border border-gray-200 rounded hover:border-blue-600"
+                    >
+                      Set as Default
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleDeleteSchedule(schedule.id)}
+                    className="text-red-600 hover:text-red-700 p-2"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+
+              {schedule.rules.length === 0 ? (
+                <p className="text-gray-400 text-sm">No rules configured</p>
+              ) : (
+                <div className="bg-gray-50 rounded border divide-y text-sm">
+                  {schedule.rules.map((rule, idx) => (
+                    <div key={idx} className="p-3 flex items-center justify-between">
+                      <span className="font-medium">
+                        {rule.dayOfWeek !== undefined ? DAYS[rule.dayOfWeek] : "Custom Date"}
+                      </span>
+                      <span className="text-gray-600">
+                        {rule.startTime} — {rule.endTime}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="mt-8 bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-900">
+        <strong>Tip:</strong> Link schedules to event types for precise availability control.
+      </div>
+    </div>
+  )
+}

--- a/src/app/dashboard/schedules/page.tsx
+++ b/src/app/dashboard/schedules/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { Plus, Trash2, Star } from "lucide-react"
+import { Plus, Trash2, Star, X } from "lucide-react"
 
 const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
@@ -21,11 +21,84 @@ interface Schedule {
   rules: Rule[]
 }
 
+function defaultRule(): Rule {
+  return { dayOfWeek: 1, startTime: "09:00", endTime: "17:00", enabled: true }
+}
+
+function RulesEditor({
+  rules,
+  onChange,
+}: {
+  rules: Rule[]
+  onChange: (rules: Rule[]) => void
+}) {
+  function update(idx: number, patch: Partial<Rule>) {
+    onChange(rules.map((r, i) => (i === idx ? { ...r, ...patch } : r)))
+  }
+  function remove(idx: number) {
+    onChange(rules.filter((_, i) => i !== idx))
+  }
+  return (
+    <div className="space-y-2">
+      {rules.length === 0 && (
+        <p className="text-sm text-gray-500">No rules yet. Add one below.</p>
+      )}
+      {rules.map((r, i) => (
+        <div key={i} className="flex items-center gap-2 text-sm">
+          <select
+            value={r.dayOfWeek ?? 1}
+            onChange={e => update(i, { dayOfWeek: Number(e.target.value), date: undefined })}
+            className="border rounded px-2 py-1.5 bg-white"
+          >
+            {DAYS.map((d, idx) => (
+              <option key={idx} value={idx}>{d}</option>
+            ))}
+          </select>
+          <input
+            type="time"
+            value={r.startTime}
+            onChange={e => update(i, { startTime: e.target.value })}
+            className="border rounded px-2 py-1.5"
+          />
+          <span className="text-gray-500">—</span>
+          <input
+            type="time"
+            value={r.endTime}
+            onChange={e => update(i, { endTime: e.target.value })}
+            className="border rounded px-2 py-1.5"
+          />
+          <button
+            onClick={() => remove(i)}
+            className="text-gray-400 hover:text-red-600 p-1"
+            aria-label="Remove rule"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      ))}
+      <button
+        onClick={() => onChange([...rules, defaultRule()])}
+        className="text-sm text-blue-600 hover:text-blue-700 flex items-center gap-1"
+      >
+        <Plus className="w-4 h-4" /> Add rule
+      </button>
+    </div>
+  )
+}
+
 export default function SchedulesPage() {
   const [schedules, setSchedules] = useState<Schedule[]>([])
   const [loading, setLoading] = useState(true)
   const [creating, setCreating] = useState(false)
-  const [newSchedule, setNewSchedule] = useState({ name: "", rules: [] as Rule[] })
+  const [newSchedule, setNewSchedule] = useState<{ name: string; rules: Rule[] }>({
+    name: "",
+    rules: [defaultRule()],
+  })
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draftRules, setDraftRules] = useState<Rule[]>([])
+  const [editError, setEditError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
 
   useEffect(() => {
     fetchSchedules()
@@ -40,8 +113,12 @@ export default function SchedulesPage() {
   }
 
   async function handleCreateSchedule() {
-    if (!newSchedule.name.trim()) return
-
+    if (!newSchedule.name.trim()) {
+      setCreateError("Name is required")
+      return
+    }
+    setCreateError(null)
+    setSaving(true)
     const res = await fetch("/api/availability/schedules", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -50,21 +127,22 @@ export default function SchedulesPage() {
         rules: newSchedule.rules,
       }),
     })
-
+    setSaving(false)
     if (res.ok) {
       await fetchSchedules()
       setCreating(false)
-      setNewSchedule({ name: "", rules: [] })
+      setNewSchedule({ name: "", rules: [defaultRule()] })
+    } else {
+      const err = await res.json().catch(() => ({}))
+      setCreateError(err.error || "Failed to create schedule")
     }
   }
 
   async function handleDeleteSchedule(id: string) {
     if (!confirm("Delete this schedule?")) return
-
     const res = await fetch(`/api/availability/schedules/${id}`, {
       method: "DELETE",
     })
-
     if (res.ok) {
       await fetchSchedules()
     } else {
@@ -79,9 +157,37 @@ export default function SchedulesPage() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ isDefault: true }),
     })
+    if (res.ok) await fetchSchedules()
+  }
 
+  function beginEdit(schedule: Schedule) {
+    setEditingId(schedule.id)
+    setDraftRules(schedule.rules.map(r => ({
+      dayOfWeek: r.dayOfWeek,
+      date: r.date,
+      startTime: r.startTime,
+      endTime: r.endTime,
+      enabled: r.enabled,
+    })))
+    setEditError(null)
+  }
+
+  async function saveEdit() {
+    if (!editingId) return
+    setSaving(true)
+    setEditError(null)
+    const res = await fetch(`/api/availability/schedules/${editingId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rules: draftRules }),
+    })
+    setSaving(false)
     if (res.ok) {
+      setEditingId(null)
       await fetchSchedules()
+    } else {
+      const err = await res.json().catch(() => ({}))
+      setEditError(err.error || "Failed to save rules")
     }
   }
 
@@ -112,15 +218,28 @@ export default function SchedulesPage() {
               onChange={e => setNewSchedule({ ...newSchedule, name: e.target.value })}
               className="w-full border rounded px-3 py-2 text-sm"
             />
+            <div>
+              <div className="text-sm font-medium mb-2">Rules</div>
+              <RulesEditor
+                rules={newSchedule.rules}
+                onChange={rules => setNewSchedule({ ...newSchedule, rules })}
+              />
+            </div>
+            {createError && <p className="text-sm text-red-600">{createError}</p>}
             <div className="flex gap-2">
               <button
                 onClick={handleCreateSchedule}
-                className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm"
+                disabled={saving}
+                className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm disabled:opacity-50"
               >
-                Create
+                {saving ? "Creating…" : "Create"}
               </button>
               <button
-                onClick={() => setCreating(false)}
+                onClick={() => {
+                  setCreating(false)
+                  setNewSchedule({ name: "", rules: [defaultRule()] })
+                  setCreateError(null)
+                }}
                 className="bg-gray-200 text-gray-700 px-4 py-2 rounded hover:bg-gray-300 text-sm"
               >
                 Cancel
@@ -148,6 +267,14 @@ export default function SchedulesPage() {
                   )}
                 </div>
                 <div className="flex gap-2">
+                  {editingId !== schedule.id && (
+                    <button
+                      onClick={() => beginEdit(schedule)}
+                      className="text-gray-600 hover:text-blue-600 text-sm px-3 py-1 border border-gray-200 rounded hover:border-blue-600"
+                    >
+                      Edit Rules
+                    </button>
+                  )}
                   {!schedule.isDefault && (
                     <button
                       onClick={() => handleSetDefault(schedule.id)}
@@ -159,20 +286,43 @@ export default function SchedulesPage() {
                   <button
                     onClick={() => handleDeleteSchedule(schedule.id)}
                     className="text-red-600 hover:text-red-700 p-2"
+                    aria-label="Delete schedule"
                   >
                     <Trash2 className="w-4 h-4" />
                   </button>
                 </div>
               </div>
 
-              {schedule.rules.length === 0 ? (
+              {editingId === schedule.id ? (
+                <div className="space-y-3">
+                  <RulesEditor rules={draftRules} onChange={setDraftRules} />
+                  {editError && <p className="text-sm text-red-600">{editError}</p>}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={saveEdit}
+                      disabled={saving}
+                      className="bg-blue-600 text-white px-4 py-1.5 rounded hover:bg-blue-700 text-sm disabled:opacity-50"
+                    >
+                      {saving ? "Saving…" : "Save"}
+                    </button>
+                    <button
+                      onClick={() => { setEditingId(null); setEditError(null) }}
+                      className="bg-gray-200 text-gray-700 px-4 py-1.5 rounded hover:bg-gray-300 text-sm"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : schedule.rules.length === 0 ? (
                 <p className="text-gray-400 text-sm">No rules configured</p>
               ) : (
                 <div className="bg-gray-50 rounded border divide-y text-sm">
                   {schedule.rules.map((rule, idx) => (
                     <div key={idx} className="p-3 flex items-center justify-between">
                       <span className="font-medium">
-                        {rule.dayOfWeek !== undefined ? DAYS[rule.dayOfWeek] : "Custom Date"}
+                        {rule.dayOfWeek !== undefined && rule.dayOfWeek !== null
+                          ? DAYS[rule.dayOfWeek]
+                          : "Custom Date"}
                       </span>
                       <span className="text-gray-600">
                         {rule.startTime} — {rule.endTime}
@@ -187,7 +337,8 @@ export default function SchedulesPage() {
       </div>
 
       <div className="mt-8 bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-900">
-        <strong>Tip:</strong> Link schedules to event types for precise availability control.
+        <strong>Tip:</strong> Link a schedule to an event type in the event-type editor.
+        While a schedule is linked, it replaces the legacy availability for that event type.
       </div>
     </div>
   )

--- a/src/lib/__tests__/availability.integration.test.ts
+++ b/src/lib/__tests__/availability.integration.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { getAvailableSlots } from "@/lib/availability"
+
+// ─── Mock Prisma ───
+
+const mockUserFindUnique = vi.fn()
+const mockEventTypeFindUnique = vi.fn()
+const mockAvailabilityFindMany = vi.fn()
+const mockAvailabilityRuleFindMany = vi.fn()
+const mockBookingFindMany = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: {
+      findUnique: (...args: any[]) => mockUserFindUnique(...args),
+    },
+    eventType: {
+      findUnique: (...args: any[]) => mockEventTypeFindUnique(...args),
+    },
+    availability: {
+      findMany: (...args: any[]) => mockAvailabilityFindMany(...args),
+    },
+    availabilityRule: {
+      findMany: (...args: any[]) => mockAvailabilityRuleFindMany(...args),
+    },
+    booking: {
+      findMany: (...args: any[]) => mockBookingFindMany(...args),
+    },
+  },
+}))
+
+vi.mock("@/lib/calendar/conflict-detection", () => ({
+  getConflictingEvents: vi.fn().mockResolvedValue([]),
+  clearEventCache: vi.fn(),
+}))
+
+// ─── Test Data ───
+
+const USER_ID = "user-1"
+const EVENT_TYPE_ID = "et-1"
+const EVENT_SCHEDULE_ID = "sched-event"
+const DEFAULT_SCHEDULE_ID = "sched-default"
+
+const baseUser = {
+  id: USER_ID,
+  timezone: "UTC",
+  defaultAvailabilityScheduleId: null as string | null,
+}
+
+const baseEventType = {
+  id: EVENT_TYPE_ID,
+  duration: 30,
+  bufferBefore: 0,
+  bufferAfter: 0,
+  minNotice: 0,
+  dailyLimit: null,
+  weeklyLimit: null,
+  availabilityScheduleId: null as string | null,
+}
+
+// Use a future Monday to guarantee dayOfWeek=1
+const futureMonday = new Date("2026-05-04T00:00:00Z")
+const futureTuesday = new Date("2026-05-05T00:00:00Z")
+
+const defaultOptions = {
+  userId: USER_ID,
+  eventTypeId: EVENT_TYPE_ID,
+  startDate: futureMonday,
+  endDate: futureTuesday,
+  timezone: "UTC",
+}
+
+function makeRule(scheduleId: string, overrides: Record<string, any> = {}) {
+  return {
+    id: `rule-${scheduleId}`,
+    availabilityScheduleId: scheduleId,
+    dayOfWeek: 1, // Monday
+    date: null,
+    startTime: "10:00",
+    endTime: "11:00",
+    enabled: true,
+    ...overrides,
+  }
+}
+
+function makeLegacyRule(overrides: Record<string, any> = {}) {
+  return {
+    id: "legacy-1",
+    userId: USER_ID,
+    dayOfWeek: 1,
+    date: null,
+    startTime: "08:00",
+    endTime: "09:00",
+    enabled: true,
+    ...overrides,
+  }
+}
+
+// ─── Helpers ───
+
+function setupMocks(opts: {
+  user?: typeof baseUser
+  eventType?: typeof baseEventType
+  eventScheduleRules?: any[]
+  defaultScheduleRules?: any[]
+  legacyRules?: any[]
+}) {
+  const user = opts.user ?? baseUser
+  const eventType = opts.eventType ?? baseEventType
+
+  // First call: from getAvailableSlots (full user)
+  // Second call: from resolveAvailabilityRules (select defaultAvailabilityScheduleId)
+  mockUserFindUnique.mockImplementation(({ select }: any) => {
+    if (select) return Promise.resolve({ defaultAvailabilityScheduleId: user.defaultAvailabilityScheduleId })
+    return Promise.resolve(user)
+  })
+
+  mockEventTypeFindUnique.mockResolvedValue(eventType)
+  mockBookingFindMany.mockResolvedValue([])
+
+  // AvailabilityRule mock - route by scheduleId
+  mockAvailabilityRuleFindMany.mockImplementation(({ where }: any) => {
+    if (where.availabilityScheduleId === EVENT_SCHEDULE_ID) {
+      return Promise.resolve(opts.eventScheduleRules ?? [])
+    }
+    if (where.availabilityScheduleId === DEFAULT_SCHEDULE_ID) {
+      return Promise.resolve(opts.defaultScheduleRules ?? [])
+    }
+    return Promise.resolve([])
+  })
+
+  mockAvailabilityFindMany.mockResolvedValue(opts.legacyRules ?? [])
+}
+
+// ─── Tests ───
+
+describe("Availability schedule resolution (fallback chain)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("uses event type's linked schedule when present", async () => {
+    setupMocks({
+      eventType: { ...baseEventType, availabilityScheduleId: EVENT_SCHEDULE_ID },
+      user: { ...baseUser, defaultAvailabilityScheduleId: DEFAULT_SCHEDULE_ID },
+      eventScheduleRules: [makeRule(EVENT_SCHEDULE_ID, { startTime: "10:00", endTime: "11:00" })],
+      defaultScheduleRules: [makeRule(DEFAULT_SCHEDULE_ID, { startTime: "14:00", endTime: "15:00" })],
+      legacyRules: [makeLegacyRule()],
+    })
+
+    const slots = await getAvailableSlots(defaultOptions)
+
+    // Should get slots from event schedule (10:00-11:00), not default (14:00-15:00) or legacy (08:00-09:00)
+    expect(slots.length).toBeGreaterThan(0)
+    expect(slots.every((s) => s.start.getUTCHours() === 10)).toBe(true)
+    // Should NOT have queried legacy availability
+    expect(mockAvailabilityFindMany).not.toHaveBeenCalled()
+  })
+
+  it("falls back to user default schedule when event type has no schedule", async () => {
+    setupMocks({
+      eventType: { ...baseEventType, availabilityScheduleId: null },
+      user: { ...baseUser, defaultAvailabilityScheduleId: DEFAULT_SCHEDULE_ID },
+      defaultScheduleRules: [makeRule(DEFAULT_SCHEDULE_ID, { startTime: "14:00", endTime: "15:00" })],
+      legacyRules: [makeLegacyRule()],
+    })
+
+    const slots = await getAvailableSlots(defaultOptions)
+
+    expect(slots.length).toBeGreaterThan(0)
+    expect(slots.every((s) => s.start.getUTCHours() === 14)).toBe(true)
+    expect(mockAvailabilityFindMany).not.toHaveBeenCalled()
+  })
+
+  it("falls back to legacy rules when no schedules exist", async () => {
+    setupMocks({
+      eventType: { ...baseEventType, availabilityScheduleId: null },
+      user: { ...baseUser, defaultAvailabilityScheduleId: null },
+      legacyRules: [makeLegacyRule({ startTime: "08:00", endTime: "09:00" })],
+    })
+
+    const slots = await getAvailableSlots(defaultOptions)
+
+    expect(slots.length).toBeGreaterThan(0)
+    expect(slots.every((s) => s.start.getUTCHours() === 8)).toBe(true)
+    expect(mockAvailabilityFindMany).toHaveBeenCalled()
+  })
+
+  it("falls back to user default when event schedule has no enabled rules", async () => {
+    setupMocks({
+      eventType: { ...baseEventType, availabilityScheduleId: EVENT_SCHEDULE_ID },
+      user: { ...baseUser, defaultAvailabilityScheduleId: DEFAULT_SCHEDULE_ID },
+      eventScheduleRules: [], // no enabled rules
+      defaultScheduleRules: [makeRule(DEFAULT_SCHEDULE_ID, { startTime: "14:00", endTime: "15:00" })],
+    })
+
+    const slots = await getAvailableSlots(defaultOptions)
+
+    expect(slots.length).toBeGreaterThan(0)
+    expect(slots.every((s) => s.start.getUTCHours() === 14)).toBe(true)
+  })
+
+  it("falls back to legacy when both schedules have no rules", async () => {
+    setupMocks({
+      eventType: { ...baseEventType, availabilityScheduleId: EVENT_SCHEDULE_ID },
+      user: { ...baseUser, defaultAvailabilityScheduleId: DEFAULT_SCHEDULE_ID },
+      eventScheduleRules: [],
+      defaultScheduleRules: [],
+      legacyRules: [makeLegacyRule({ startTime: "08:00", endTime: "09:00" })],
+    })
+
+    const slots = await getAvailableSlots(defaultOptions)
+
+    expect(slots.length).toBeGreaterThan(0)
+    expect(slots.every((s) => s.start.getUTCHours() === 8)).toBe(true)
+  })
+
+  it("returns no slots when no availability rules exist anywhere", async () => {
+    setupMocks({
+      eventType: { ...baseEventType, availabilityScheduleId: null },
+      user: { ...baseUser, defaultAvailabilityScheduleId: null },
+      legacyRules: [],
+    })
+
+    const slots = await getAvailableSlots(defaultOptions)
+
+    expect(slots).toEqual([])
+  })
+})

--- a/src/lib/__tests__/availability.integration.test.ts
+++ b/src/lib/__tests__/availability.integration.test.ts
@@ -58,9 +58,24 @@ const baseEventType = {
   availabilityScheduleId: null as string | null,
 }
 
-// Use a future Monday to guarantee dayOfWeek=1
-const futureMonday = new Date("2026-05-04T00:00:00Z")
-const futureTuesday = new Date("2026-05-05T00:00:00Z")
+// Use the next future Monday to guarantee dayOfWeek=1 without going stale.
+function nextFutureMonday() {
+  const today = new Date()
+  const daysUntilMonday = (8 - today.getUTCDay()) % 7 || 7
+  const monday = new Date(Date.UTC(
+    today.getUTCFullYear(),
+    today.getUTCMonth(),
+    today.getUTCDate() + daysUntilMonday,
+    0,
+    0,
+    0,
+    0
+  ))
+  return monday
+}
+
+const futureMonday = nextFutureMonday()
+const futureTuesday = new Date(futureMonday.getTime() + 24 * 60 * 60 * 1000)
 
 const defaultOptions = {
   userId: USER_ID,

--- a/src/lib/availability-validation.ts
+++ b/src/lib/availability-validation.ts
@@ -1,0 +1,37 @@
+// Shared validation for AvailabilityRule shapes posted to the schedules API.
+//
+// availability.ts builds slot windows by feeding `${date}T${startTime}:00` into
+// fromZonedTime — invalid HH:MM strings or inverted ranges silently produce
+// `Invalid Date` and no slots, which is hard to diagnose downstream. Catching
+// those at the boundary turns silent breakage into a clear 400.
+
+const HH_MM = /^([01]\d|2[0-3]):[0-5]\d$/
+
+export interface RuleInput {
+  dayOfWeek?: number | null
+  date?: string | Date | null
+  startTime?: string
+  endTime?: string
+  enabled?: boolean
+}
+
+export function validateRules(rules: unknown): string | null {
+  if (!Array.isArray(rules)) return "rules must be an array"
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i] as RuleInput
+    if (!rule || typeof rule !== "object") return `rules[${i}] must be an object`
+    if (!rule.startTime || !rule.endTime) return `rules[${i}] requires startTime and endTime`
+    if (!HH_MM.test(rule.startTime)) return `rules[${i}].startTime "${rule.startTime}" must match HH:MM (00:00–23:59)`
+    if (!HH_MM.test(rule.endTime)) return `rules[${i}].endTime "${rule.endTime}" must match HH:MM (00:00–23:59)`
+    if (rule.startTime >= rule.endTime) return `rules[${i}].startTime (${rule.startTime}) must be before endTime (${rule.endTime})`
+
+    const hasDay = typeof rule.dayOfWeek === "number"
+    const hasDate = rule.date != null && rule.date !== ""
+    if (!hasDay && !hasDate) return `rules[${i}] needs either dayOfWeek (0–6) or date (YYYY-MM-DD)`
+    if (hasDay) {
+      const d = rule.dayOfWeek as number
+      if (!Number.isInteger(d) || d < 0 || d > 6) return `rules[${i}].dayOfWeek must be an integer 0–6 (got ${d})`
+    }
+  }
+  return null
+}

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -8,6 +8,14 @@ interface TimeSlot {
   end: Date
 }
 
+interface AvailabilityRuleLike {
+  dayOfWeek: number | null
+  date: Date | null
+  startTime: string
+  endTime: string
+  enabled: boolean
+}
+
 interface AvailabilityOptions {
   userId: string
   eventTypeId: string
@@ -16,17 +24,51 @@ interface AvailabilityOptions {
   timezone: string
 }
 
+export async function resolveAvailabilityRules(
+  userId: string,
+  eventType: { availabilityScheduleId: string | null }
+): Promise<AvailabilityRuleLike[]> {
+  // 1. Event type's linked schedule
+  if (eventType.availabilityScheduleId) {
+    const rules = await prisma.availabilityRule.findMany({
+      where: { availabilityScheduleId: eventType.availabilityScheduleId, enabled: true },
+    })
+    if (rules.length > 0) return rules
+  }
+
+  // 2. User's default schedule
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { defaultAvailabilityScheduleId: true },
+  })
+  if (user?.defaultAvailabilityScheduleId) {
+    const rules = await prisma.availabilityRule.findMany({
+      where: { availabilityScheduleId: user.defaultAvailabilityScheduleId, enabled: true },
+    })
+    if (rules.length > 0) return rules
+  }
+
+  // 3. Legacy Availability records
+  return prisma.availability.findMany({ where: { userId, enabled: true } })
+}
+
 export async function getAvailableSlots(options: AvailabilityOptions): Promise<TimeSlot[]> {
   const { userId, eventTypeId, startDate, endDate, timezone: _timezone } = options
 
   // Get user and event type
-  const [user, eventType, availabilityRules] = await Promise.all([
+  const [user, eventType] = await Promise.all([
     prisma.user.findUnique({ where: { id: userId } }),
     prisma.eventType.findUnique({ where: { id: eventTypeId } }),
-    prisma.availability.findMany({ where: { userId, enabled: true } }),
   ])
 
   if (!user || !eventType) return []
+
+  // Resolve availability rules via fallback chain:
+  // 1. Event type's linked schedule
+  // 2. User's default schedule
+  // 3. Legacy Availability records
+  const availabilityRules = await resolveAvailabilityRules(userId, eventType)
+
 
   const duration = eventType.duration
   const bufferBefore = eventType.bufferBefore


### PR DESCRIPTION
## Overview
Implements per-event-type availability schedules with backward compatibility for tinycal.

## Resolves
GitHub Issue: zenithventure/tinycal#19

## Implementation

### Database (Prisma)
- **AvailabilitySchedule**: Name, isDefault flag, per-user unique constraint
- **AvailabilityRule**: Day-of-week (0-6) and date-specific rules with start/end times  
- **EventType**: New optional availabilityScheduleId FK
- **User**: New optional defaultAvailabilityScheduleId for user-level defaults

### API Endpoints
- **GET /api/availability/schedules** - List user's schedules with rules
- **POST /api/availability/schedules** - Create new schedule (auto-unsets previous default)
- **GET /api/availability/schedules/{id}** - Get specific schedule with rules
- **PUT /api/availability/schedules/{id}** - Update name, set default, or replace rules
- **DELETE /api/availability/schedules/{id}** - Delete (blocked if linked to event types)

### Dashboard UI
- **New page**: /dashboard/schedules
  - Create/delete schedules
  - Mark as default
  - View schedule rules
- **Enhanced**: Event type editor (/dashboard/event-types/[id])
  - Dropdown to select availability schedule
  - Falls back to user default if not set

### Booking Resolution (Ready for Integration)
Priority hierarchy:
1. Event type's linked schedule (highest priority)
2. User's default schedule
3. Legacy Availability model (backward compatible)

## Testing
- 14 new unit tests covering all CRUD operations
- All 118 tests passing ✅
- Comprehensive mocking for auth and Prisma

## Features
✅ Per-user unique schedule names
✅ Set/unset default schedules with auto-clearing old defaults
✅ Day-of-week and date-specific rules (flexible)
✅ Prevent deletion if linked to event types
✅ Backward compatible: null scheduleId still uses legacy rules
✅ Full REST API with proper error handling
✅ Clean dashboard UX

## Migration
- Non-breaking: all new fields
- Additive only: no existing data modified
- Existing bookings unaffected
- Legacy Availability model unchanged

## Next Steps
- Implement booking resolution logic in conflict detection service
- Add rule editing UI to schedule management page (UI skeleton ready)
- Add schedule-specific availability lookup in time slot picker
