### PR TITLE
fix: check all hosts for conflicts when booking collective event types

### DIFF
--- a/src/app/api/bookings/[uid]/reschedule/route.ts
+++ b/src/app/api/bookings/[uid]/reschedule/route.ts
@@ -4,6 +4,7 @@ import { sendEmail, bookingConfirmationEmail } from "@/lib/email"
 import { updateGoogleCalendarEvent, createGoogleCalendarEvent } from "@/lib/calendar/google"
 import { updateOutlookCalendarEvent, createOutlookCalendarEvent } from "@/lib/calendar/outlook"
 import { triggerWebhooks } from "@/lib/webhooks"
+import { hasBookingConflict } from "@/lib/bookings/conflict-check"
 import { format } from "date-fns"
 import { toZonedTime } from "date-fns-tz"
 
@@ -22,16 +23,16 @@ export async function POST(req: Request, { params }: { params: { uid: string } }
   const start = new Date(newStartTime)
   const end = new Date(start.getTime() + booking.eventType.duration * 60000)
 
-  // Check for conflicts
-  const conflict = await prisma.booking.findFirst({
-    where: {
-      userId: booking.userId,
-      status: { in: ["CONFIRMED", "PENDING"] },
-      id: { not: booking.id },
-      OR: [{ startTime: { lt: end }, endTime: { gt: start } }],
-    },
-  })
-  if (conflict) return NextResponse.json({ error: "Time slot no longer available" }, { status: 409 })
+  if (
+    await hasBookingConflict({
+      eventType: booking.eventType,
+      start,
+      end,
+      excludeBookingId: booking.id,
+    })
+  ) {
+    return NextResponse.json({ error: "Time slot no longer available" }, { status: 409 })
+  }
 
   // Update existing calendar event in-place (preserves event thread, attendee responses, Meet link)
   let meetingUrl = booking.meetingUrl || undefined

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -6,6 +6,7 @@ import { createGoogleCalendarEvent } from "@/lib/calendar/google"
 import { createOutlookCalendarEvent } from "@/lib/calendar/outlook"
 import { createZoomMeeting } from "@/lib/video"
 import { triggerWebhooks } from "@/lib/webhooks"
+import { hasBookingConflict } from "@/lib/bookings/conflict-check"
 import { format } from "date-fns"
 import { toZonedTime } from "date-fns-tz"
 
@@ -36,17 +37,9 @@ export async function POST(req: Request) {
     const start = new Date(startTime)
     const end = new Date(start.getTime() + eventType.duration * 60000)
 
-    // Check for conflicts
-    const conflict = await prisma.booking.findFirst({
-      where: {
-        userId: eventType.userId,
-        status: { in: ["CONFIRMED", "PENDING"] },
-        OR: [
-          { startTime: { lt: end }, endTime: { gt: start } },
-        ],
-      },
-    })
-    if (conflict) return NextResponse.json({ error: "Time slot no longer available" }, { status: 409 })
+    if (await hasBookingConflict({ eventType, start, end })) {
+      return NextResponse.json({ error: "Time slot no longer available" }, { status: 409 })
+    }
 
     // Generate meeting link
     let meetingUrl: string | undefined

--- a/src/lib/bookings/__tests__/conflict-check.test.ts
+++ b/src/lib/bookings/__tests__/conflict-check.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { hasBookingConflict } from "../conflict-check"
+
+const mockBookingFindFirst = vi.fn()
+const mockGetConflictingEvents = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    booking: {
+      findFirst: (...args: any[]) => mockBookingFindFirst(...args),
+    },
+  },
+}))
+
+vi.mock("@/lib/calendar/conflict-detection", () => ({
+  getConflictingEvents: (...args: any[]) => mockGetConflictingEvents(...args),
+}))
+
+const START = new Date("2026-06-01T10:00:00Z")
+const END = new Date("2026-06-01T10:30:00Z")
+
+const SOLO_EVENT_TYPE = {
+  id: "et-1",
+  userId: "user-owner",
+  isCollective: false,
+  collectiveMembers: [] as string[],
+}
+
+const COLLECTIVE_EVENT_TYPE = {
+  id: "et-collective",
+  userId: "user-sze",
+  isCollective: true,
+  collectiveMembers: ["user-alex"],
+}
+
+describe("hasBookingConflict", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockBookingFindFirst.mockResolvedValue(null)
+    mockGetConflictingEvents.mockResolvedValue([])
+  })
+
+  describe("non-collective", () => {
+    it("returns false when owner has no DB or calendar conflicts", async () => {
+      const result = await hasBookingConflict({
+        eventType: SOLO_EVENT_TYPE,
+        start: START,
+        end: END,
+      })
+
+      expect(result).toBe(false)
+      expect(mockBookingFindFirst).toHaveBeenCalledTimes(1)
+      expect(mockBookingFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId: "user-owner" }),
+        })
+      )
+    })
+
+    it("returns true when owner has a DB conflict", async () => {
+      mockBookingFindFirst.mockResolvedValueOnce({ id: "existing-booking" })
+
+      const result = await hasBookingConflict({
+        eventType: SOLO_EVENT_TYPE,
+        start: START,
+        end: END,
+      })
+
+      expect(result).toBe(true)
+    })
+
+    it("returns true when owner's connected calendar is busy", async () => {
+      mockGetConflictingEvents.mockResolvedValueOnce([
+        { start: START, end: END, calendarId: "primary", provider: "GOOGLE" },
+      ])
+
+      const result = await hasBookingConflict({
+        eventType: SOLO_EVENT_TYPE,
+        start: START,
+        end: END,
+      })
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe("collective", () => {
+    it("checks every host (owner + collective members)", async () => {
+      await hasBookingConflict({
+        eventType: COLLECTIVE_EVENT_TYPE,
+        start: START,
+        end: END,
+      })
+
+      const checkedUserIds = mockBookingFindFirst.mock.calls.map(
+        (call: any[]) => call[0].where.userId
+      )
+      expect(checkedUserIds.sort()).toEqual(["user-alex", "user-sze"])
+
+      const calendarUserIds = mockGetConflictingEvents.mock.calls.map(
+        (call: any[]) => call[0]
+      )
+      expect(calendarUserIds.sort()).toEqual(["user-alex", "user-sze"])
+    })
+
+    it("returns true when a collective member has a DB conflict", async () => {
+      mockBookingFindFirst.mockImplementation(({ where }: any) =>
+        where.userId === "user-alex"
+          ? Promise.resolve({ id: "alex-existing-booking" })
+          : Promise.resolve(null)
+      )
+
+      const result = await hasBookingConflict({
+        eventType: COLLECTIVE_EVENT_TYPE,
+        start: START,
+        end: END,
+      })
+
+      expect(result).toBe(true)
+    })
+
+    it("returns true when a collective member's calendar is busy", async () => {
+      mockGetConflictingEvents.mockImplementation((userId: string) =>
+        userId === "user-alex"
+          ? Promise.resolve([
+              { start: START, end: END, calendarId: "primary", provider: "GOOGLE" },
+            ])
+          : Promise.resolve([])
+      )
+
+      const result = await hasBookingConflict({
+        eventType: COLLECTIVE_EVENT_TYPE,
+        start: START,
+        end: END,
+      })
+
+      expect(result).toBe(true)
+    })
+
+    it("dedupes the owner if also listed in collectiveMembers", async () => {
+      await hasBookingConflict({
+        eventType: {
+          ...COLLECTIVE_EVENT_TYPE,
+          collectiveMembers: ["user-sze", "user-alex"],
+        },
+        start: START,
+        end: END,
+      })
+
+      // Owner should only be queried once even though listed twice
+      const checkedUserIds = mockBookingFindFirst.mock.calls.map(
+        (call: any[]) => call[0].where.userId
+      )
+      const szeCount = checkedUserIds.filter((u: string) => u === "user-sze").length
+      expect(szeCount).toBe(1)
+    })
+  })
+
+  describe("excludeBookingId", () => {
+    it("excludes the specified booking id from the DB conflict query", async () => {
+      await hasBookingConflict({
+        eventType: SOLO_EVENT_TYPE,
+        start: START,
+        end: END,
+        excludeBookingId: "this-booking",
+      })
+
+      expect(mockBookingFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: { not: "this-booking" } }),
+        })
+      )
+    })
+
+    it("does not add an id filter when excludeBookingId is omitted", async () => {
+      await hasBookingConflict({
+        eventType: SOLO_EVENT_TYPE,
+        start: START,
+        end: END,
+      })
+
+      const where = mockBookingFindFirst.mock.calls[0][0].where
+      expect(where).not.toHaveProperty("id")
+    })
+  })
+})

--- a/src/lib/bookings/conflict-check.ts
+++ b/src/lib/bookings/conflict-check.ts
@@ -1,0 +1,54 @@
+import prisma from "@/lib/prisma"
+import { getConflictingEvents } from "@/lib/calendar/conflict-detection"
+
+interface ConflictCheckOptions {
+  eventType: {
+    id: string
+    userId: string
+    isCollective: boolean
+    collectiveMembers: string[]
+  }
+  start: Date
+  end: Date
+  excludeBookingId?: string
+}
+
+// Returns true if any host (owner + collective members) has a conflicting DB
+// booking or connected-calendar event overlapping [start, end). Mirrors the
+// busy-time check getAvailableSlots performs at slot-listing time so a
+// late-arriving co-host conflict can't slip through booking POST.
+export async function hasBookingConflict({
+  eventType,
+  start,
+  end,
+  excludeBookingId,
+}: ConflictCheckOptions): Promise<boolean> {
+  const hostIds = eventType.isCollective
+    ? [eventType.userId, ...eventType.collectiveMembers]
+    : [eventType.userId]
+
+  const uniqueHostIds = Array.from(new Set(hostIds))
+
+  const results = await Promise.all(
+    uniqueHostIds.map(async (userId) => {
+      const [dbConflict, calendarBusy] = await Promise.all([
+        prisma.booking.findFirst({
+          where: {
+            userId,
+            status: { in: ["CONFIRMED", "PENDING"] },
+            ...(excludeBookingId && { id: { not: excludeBookingId } }),
+            startTime: { lt: end },
+            endTime: { gt: start },
+          },
+          select: { id: true },
+        }),
+        getConflictingEvents(userId, start, end, eventType.id),
+      ])
+
+      if (dbConflict) return true
+      return calendarBusy.some((e) => e.start < end && e.end > start)
+    })
+  )
+
+  return results.some(Boolean)
+}


### PR DESCRIPTION
## Summary
- Extracted `hasBookingConflict()` to `src/lib/bookings/conflict-check.ts` that queries DB bookings and connected-calendar busy times for *every* host of a collective event type
- Wired it into `POST /api/bookings` and `POST /api/bookings/[uid]/reschedule` (the two places that did the old single-owner conflict query)
- Added 9 unit tests covering solo + collective + dedup + excludeBookingId

## Why
`/api/slots` already intersects availability across `eventType.userId + collectiveMembers`, but the booking POST only checked the event-type owner. Between slot fetch and POST, a co-host could pick up a calendar event or get booked elsewhere — and the POST would still succeed, double-booking them.

Same fix applied to reschedule.

Closes #34
Part of #33

## Test plan
- [x] `npx vitest run src/lib/bookings` — 9/9 pass
- [x] Full unit suite (`npx vitest run`) — 50/50 pass
- [ ] Manual smoke: book a collective event type where one co-host has a conflicting Google Calendar event → expect 409
- [ ] Manual smoke: reschedule onto a slot where co-host now has a conflict → expect 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)