### PR TITLE
feat: real API keys (backend) — hashed secrets, per-key rate limit, legacy fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,19 @@ See `.env.example` for all required variables. Key variables:
 
 ### REST API (v1)
 
-All API requests require `Authorization: Bearer <user-id>` header.
+All API requests require `Authorization: Bearer <api-key>` header.
+
+API keys are minted in **Settings → API Keys** (or, until that ships, via
+`npx tsx scripts/create-api-key.ts <userIdOrEmail> "<name>"`). Keys have the
+form `tc_live_<prefix>_<secret>` and are only shown once at creation.
+
+Per-key rate limit: **60 requests/minute**. Responses include
+`X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`
+(epoch seconds) headers; `429` responses include `Retry-After` (seconds).
+
+> **Deprecated:** passing your raw `User.id` as the Bearer token still works
+> but returns a `Warning: 299 - "tc-legacy-api-key"` header. This path will
+> be removed in a future release — migrate to a real API key.
 
 #### Event Types
 - `GET /api/v1/event-types` — List all event types

--- a/prisma/migrations/20260509000000_add_api_keys/migration.sql
+++ b/prisma/migrations/20260509000000_add_api_keys/migration.sql
@@ -1,0 +1,43 @@
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "hashedSecret" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "scopes" TEXT[],
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApiKeyUsage" (
+    "id" TEXT NOT NULL,
+    "apiKeyId" TEXT NOT NULL,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "ApiKeyUsage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_prefix_key" ON "ApiKey"("prefix");
+
+-- CreateIndex
+CREATE INDEX "ApiKey_userId_idx" ON "ApiKey"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKeyUsage_apiKeyId_windowStart_key" ON "ApiKeyUsage"("apiKeyId", "windowStart");
+
+-- CreateIndex
+CREATE INDEX "ApiKeyUsage_windowStart_idx" ON "ApiKeyUsage"("windowStart");
+
+-- AddForeignKey
+ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApiKeyUsage" ADD CONSTRAINT "ApiKeyUsage_apiKeyId_fkey" FOREIGN KEY ("apiKeyId") REFERENCES "ApiKey"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
   webhooks       Webhook[]
   contacts       Contact[]
   documents      Document[]
+  apiKeys        ApiKey[]
 }
 
 enum Plan {
@@ -264,6 +265,40 @@ model Contact {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, email])
+}
+
+// ─── API Keys ───
+
+model ApiKey {
+  id           String    @id @default(cuid())
+  userId       String
+  prefix       String    @unique // 8-hex public lookup key, also displayed in UI
+  hashedSecret String             // sha256(secret) hex; 32-byte random secret
+  name         String             // user-given label, e.g. "Mira concierge bot"
+  scopes       String[]           // future-proofing; empty = full account access
+  lastUsedAt   DateTime?
+  expiresAt    DateTime?
+  revokedAt    DateTime?
+  createdAt    DateTime  @default(now())
+
+  user  User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  usage ApiKeyUsage[]
+
+  @@index([userId])
+}
+
+// Per-minute counter for rate limiting. One row per (key, minute window).
+// Old rows can be pruned by cron; the unique constraint enables upsert-increment.
+model ApiKeyUsage {
+  id          String   @id @default(cuid())
+  apiKeyId    String
+  windowStart DateTime // truncated to start of minute (UTC)
+  count       Int      @default(0)
+
+  apiKey ApiKey @relation(fields: [apiKeyId], references: [id], onDelete: Cascade)
+
+  @@unique([apiKeyId, windowStart])
+  @@index([windowStart])
 }
 
 // ─── Documents (E-Signature - schema ready for Module 2) ───

--- a/scripts/create-api-key.ts
+++ b/scripts/create-api-key.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-console */
+// Mints a new API key for a user. Until the Settings → API Keys dashboard
+// ships, ops uses this script to provision keys for server-to-server clients
+// (e.g. the Mira concierge bot).
+//
+// Usage:
+//   npx tsx scripts/create-api-key.ts <userIdOrEmail> "<name>"
+//
+// Example:
+//   npx tsx scripts/create-api-key.ts user@example.com "Mira concierge"
+//
+// The full key is printed exactly once. Save it somewhere safe (e.g. AWS
+// Secrets Manager, the bot's deploy env). It cannot be retrieved later — if
+// lost, revoke and mint a new one.
+
+import { PrismaClient } from "@prisma/client"
+import { generateApiKey } from "../src/lib/api-keys/generate"
+
+async function main() {
+  const [userIdOrEmail, name] = process.argv.slice(2)
+  if (!userIdOrEmail || !name) {
+    console.error('Usage: npx tsx scripts/create-api-key.ts <userIdOrEmail> "<name>"')
+    process.exit(1)
+  }
+
+  const prisma = new PrismaClient()
+  try {
+    const user = userIdOrEmail.includes("@")
+      ? await prisma.user.findUnique({ where: { email: userIdOrEmail } })
+      : await prisma.user.findUnique({ where: { id: userIdOrEmail } })
+
+    if (!user) {
+      console.error(`No user found for: ${userIdOrEmail}`)
+      process.exit(1)
+    }
+
+    const { fullKey, prefix, hashedSecret } = generateApiKey()
+
+    await prisma.apiKey.create({
+      data: {
+        userId: user.id,
+        prefix,
+        hashedSecret,
+        name,
+        scopes: [],
+      },
+    })
+
+    console.log(`Created API key for ${user.email ?? user.id} (${name})`)
+    console.log(`Prefix: ${prefix}`)
+    console.log(``)
+    console.log(`API Key (save this — it will not be shown again):`)
+    console.log(`  ${fullKey}`)
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/app/api/v1/bookings/route.ts
+++ b/src/app/api/v1/bookings/route.ts
@@ -1,16 +1,10 @@
 import { NextResponse } from "next/server"
 import prisma from "@/lib/prisma"
-
-async function authenticateApiKey(req: Request) {
-  const auth = req.headers.get("Authorization")
-  if (!auth?.startsWith("Bearer ")) return null
-  const apiKey = auth.slice(7)
-  return prisma.user.findUnique({ where: { id: apiKey } })
-}
+import { authenticateApiKey, isAuthFailure, applyAuthResponseHeaders } from "@/lib/api-keys/auth"
 
 export async function GET(req: Request) {
-  const user = await authenticateApiKey(req)
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  const auth = await authenticateApiKey(req)
+  if (isAuthFailure(auth)) return auth
 
   const url = new URL(req.url)
   const status = url.searchParams.get("status")
@@ -19,7 +13,7 @@ export async function GET(req: Request) {
 
   const bookings = await prisma.booking.findMany({
     where: {
-      userId: user.id,
+      userId: auth.user.id,
       ...(status && { status: status as any }),
       ...(from && { startTime: { gte: new Date(from) } }),
       ...(to && { endTime: { lte: new Date(to) } }),
@@ -28,5 +22,5 @@ export async function GET(req: Request) {
     orderBy: { startTime: "desc" },
     take: 100,
   })
-  return NextResponse.json({ data: bookings })
+  return applyAuthResponseHeaders(NextResponse.json({ data: bookings }), auth)
 }

--- a/src/app/api/v1/event-types/route.ts
+++ b/src/app/api/v1/event-types/route.ts
@@ -1,34 +1,26 @@
 import { NextResponse } from "next/server"
 import prisma from "@/lib/prisma"
-
-// Public REST API - requires API key (user's ID for now, can add proper API keys later)
-async function authenticateApiKey(req: Request) {
-  const auth = req.headers.get("Authorization")
-  if (!auth?.startsWith("Bearer ")) return null
-  const apiKey = auth.slice(7)
-  const user = await prisma.user.findUnique({ where: { id: apiKey } })
-  return user
-}
+import { authenticateApiKey, isAuthFailure, applyAuthResponseHeaders } from "@/lib/api-keys/auth"
 
 export async function GET(req: Request) {
-  const user = await authenticateApiKey(req)
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  const auth = await authenticateApiKey(req)
+  if (isAuthFailure(auth)) return auth
 
   const eventTypes = await prisma.eventType.findMany({
-    where: { userId: user.id },
+    where: { userId: auth.user.id },
     include: { questions: true, _count: { select: { bookings: true } } },
   })
-  return NextResponse.json({ data: eventTypes })
+  return applyAuthResponseHeaders(NextResponse.json({ data: eventTypes }), auth)
 }
 
 export async function POST(req: Request) {
-  const user = await authenticateApiKey(req)
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  const auth = await authenticateApiKey(req)
+  if (isAuthFailure(auth)) return auth
 
   const body = await req.json()
   const eventType = await prisma.eventType.create({
     data: {
-      userId: user.id,
+      userId: auth.user.id,
       title: body.title,
       slug: body.slug || body.title.toLowerCase().replace(/\s+/g, "-"),
       description: body.description,
@@ -36,5 +28,5 @@ export async function POST(req: Request) {
       location: body.location || "GOOGLE_MEET",
     },
   })
-  return NextResponse.json({ data: eventType }, { status: 201 })
+  return applyAuthResponseHeaders(NextResponse.json({ data: eventType }, { status: 201 }), auth)
 }

--- a/src/lib/api-keys/__tests__/auth.test.ts
+++ b/src/lib/api-keys/__tests__/auth.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { NextResponse } from "next/server"
+import { authenticateApiKey, isAuthFailure } from "../auth"
+import { generateApiKey, hashSecret } from "../generate"
+
+const mockApiKeyFindUnique = vi.fn()
+const mockApiKeyUpdate = vi.fn()
+const mockUserFindUnique = vi.fn()
+const mockUsageUpsert = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    apiKey: {
+      findUnique: (...args: any[]) => mockApiKeyFindUnique(...args),
+      update: (...args: any[]) => mockApiKeyUpdate(...args),
+    },
+    user: {
+      findUnique: (...args: any[]) => mockUserFindUnique(...args),
+    },
+    apiKeyUsage: {
+      upsert: (...args: any[]) => mockUsageUpsert(...args),
+    },
+  },
+}))
+
+function makeReq(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/v1/event-types", { headers })
+}
+
+const TEST_USER = { id: "user-1", email: "x@y.z", name: "X" } as any
+
+describe("authenticateApiKey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApiKeyUpdate.mockResolvedValue({})
+    mockUsageUpsert.mockResolvedValue({ count: 1 })
+  })
+
+  describe("missing or malformed Authorization", () => {
+    it("returns 401 when header is absent", async () => {
+      const result = await authenticateApiKey(makeReq())
+      expect(isAuthFailure(result)).toBe(true)
+      expect((result as NextResponse).status).toBe(401)
+    })
+
+    it("returns 401 when scheme is not Bearer", async () => {
+      const result = await authenticateApiKey(makeReq({ Authorization: "Basic abc" }))
+      expect(isAuthFailure(result)).toBe(true)
+    })
+
+    it("returns 401 when token is empty after Bearer", async () => {
+      const result = await authenticateApiKey(makeReq({ Authorization: "Bearer " }))
+      expect(isAuthFailure(result)).toBe(true)
+    })
+  })
+
+  describe("new API key path", () => {
+    it("authenticates a valid key", async () => {
+      const { fullKey, prefix, hashedSecret } = generateApiKey()
+
+      mockApiKeyFindUnique.mockResolvedValueOnce({
+        id: "ak-1",
+        userId: TEST_USER.id,
+        prefix,
+        hashedSecret,
+        revokedAt: null,
+        expiresAt: null,
+      })
+      mockUserFindUnique.mockResolvedValueOnce(TEST_USER)
+
+      const result = await authenticateApiKey(makeReq({ Authorization: `Bearer ${fullKey}` }))
+      expect(isAuthFailure(result)).toBe(false)
+      if (!isAuthFailure(result)) {
+        expect(result.user.id).toBe(TEST_USER.id)
+        expect(result.source).toBe("api-key")
+        expect(result.apiKeyId).toBe("ak-1")
+        expect(result.rateLimit?.remaining).toBeGreaterThanOrEqual(0)
+      }
+    })
+
+    it("rejects a key with a wrong secret (timing-safe compare)", async () => {
+      const { prefix } = generateApiKey()
+      const wrongKey = `tc_live_${prefix}_${"00".repeat(32)}`
+
+      mockApiKeyFindUnique.mockResolvedValueOnce({
+        id: "ak-1",
+        userId: TEST_USER.id,
+        prefix,
+        hashedSecret: hashSecret("a-different-secret"),
+        revokedAt: null,
+        expiresAt: null,
+      })
+
+      const result = await authenticateApiKey(makeReq({ Authorization: `Bearer ${wrongKey}` }))
+      expect(isAuthFailure(result)).toBe(true)
+      expect((result as NextResponse).status).toBe(401)
+    })
+
+    it("rejects an unknown prefix", async () => {
+      mockApiKeyFindUnique.mockResolvedValueOnce(null)
+      const result = await authenticateApiKey(
+        makeReq({ Authorization: `Bearer tc_live_deadbeef_${"a".repeat(64)}` })
+      )
+      expect(isAuthFailure(result)).toBe(true)
+    })
+
+    it("rejects a revoked key", async () => {
+      const { fullKey, prefix, hashedSecret } = generateApiKey()
+      mockApiKeyFindUnique.mockResolvedValueOnce({
+        id: "ak-1",
+        userId: TEST_USER.id,
+        prefix,
+        hashedSecret,
+        revokedAt: new Date("2026-01-01"),
+        expiresAt: null,
+      })
+      const result = await authenticateApiKey(makeReq({ Authorization: `Bearer ${fullKey}` }))
+      expect(isAuthFailure(result)).toBe(true)
+    })
+
+    it("rejects an expired key", async () => {
+      const { fullKey, prefix, hashedSecret } = generateApiKey()
+      mockApiKeyFindUnique.mockResolvedValueOnce({
+        id: "ak-1",
+        userId: TEST_USER.id,
+        prefix,
+        hashedSecret,
+        revokedAt: null,
+        expiresAt: new Date("2020-01-01"),
+      })
+      const result = await authenticateApiKey(makeReq({ Authorization: `Bearer ${fullKey}` }))
+      expect(isAuthFailure(result)).toBe(true)
+    })
+
+    it("returns 429 when rate limit is exceeded", async () => {
+      const { fullKey, prefix, hashedSecret } = generateApiKey()
+      mockApiKeyFindUnique.mockResolvedValueOnce({
+        id: "ak-1",
+        userId: TEST_USER.id,
+        prefix,
+        hashedSecret,
+        revokedAt: null,
+        expiresAt: null,
+      })
+      mockUsageUpsert.mockResolvedValueOnce({ count: 61 }) // over the 60/min limit
+
+      const result = await authenticateApiKey(makeReq({ Authorization: `Bearer ${fullKey}` }))
+      expect(isAuthFailure(result)).toBe(true)
+      const res = result as NextResponse
+      expect(res.status).toBe(429)
+      expect(res.headers.get("Retry-After")).not.toBeNull()
+      expect(res.headers.get("X-RateLimit-Remaining")).toBe("0")
+    })
+  })
+
+  describe("legacy User.id path", () => {
+    it("falls back to User.id lookup for non-tc_live tokens", async () => {
+      mockUserFindUnique.mockResolvedValueOnce(TEST_USER)
+      const result = await authenticateApiKey(makeReq({ Authorization: `Bearer ${TEST_USER.id}` }))
+      expect(isAuthFailure(result)).toBe(false)
+      if (!isAuthFailure(result)) {
+        expect(result.source).toBe("legacy-user-id")
+        expect(result.user.id).toBe(TEST_USER.id)
+      }
+      // Should NOT have hit the apiKey table
+      expect(mockApiKeyFindUnique).not.toHaveBeenCalled()
+    })
+
+    it("rejects an unknown legacy token", async () => {
+      mockUserFindUnique.mockResolvedValueOnce(null)
+      const result = await authenticateApiKey(makeReq({ Authorization: "Bearer unknown-cuid" }))
+      expect(isAuthFailure(result)).toBe(true)
+    })
+  })
+})

--- a/src/lib/api-keys/__tests__/generate.test.ts
+++ b/src/lib/api-keys/__tests__/generate.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest"
+import { generateApiKey, hashSecret, parseApiKey, KEY_PREFIX } from "../generate"
+
+describe("generateApiKey", () => {
+  it("produces a key with the tc_live_ prefix", () => {
+    const { fullKey } = generateApiKey()
+    expect(fullKey.startsWith(KEY_PREFIX)).toBe(true)
+  })
+
+  it("produces a parseable key matching its stored prefix and hash", () => {
+    const { fullKey, prefix, hashedSecret } = generateApiKey()
+    const parsed = parseApiKey(fullKey)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.prefix).toBe(prefix)
+    expect(hashSecret(parsed!.secret)).toBe(hashedSecret)
+  })
+
+  it("produces unique keys on repeated calls", () => {
+    const a = generateApiKey()
+    const b = generateApiKey()
+    expect(a.fullKey).not.toBe(b.fullKey)
+    expect(a.prefix).not.toBe(b.prefix)
+    expect(a.hashedSecret).not.toBe(b.hashedSecret)
+  })
+
+  it("uses 8-char hex prefix and 64-char hex secret", () => {
+    const { prefix, hashedSecret } = generateApiKey()
+    expect(prefix).toMatch(/^[0-9a-f]{8}$/)
+    expect(hashedSecret).toMatch(/^[0-9a-f]{64}$/) // sha256 hex
+  })
+})
+
+describe("parseApiKey", () => {
+  it("returns null for tokens without the tc_live_ prefix", () => {
+    expect(parseApiKey("user-cuid-12345")).toBeNull()
+    expect(parseApiKey("Bearer foo")).toBeNull()
+    expect(parseApiKey("")).toBeNull()
+  })
+
+  it("returns null for tc_live_ tokens missing a separator", () => {
+    expect(parseApiKey("tc_live_abcdef")).toBeNull()
+  })
+
+  it("returns null for tc_live_ tokens with non-hex parts", () => {
+    expect(parseApiKey("tc_live_zzzzzzzz_abcdef")).toBeNull()
+    expect(parseApiKey("tc_live_abcdef12_zzzz")).toBeNull()
+  })
+
+  it("returns null when prefix or secret is empty", () => {
+    expect(parseApiKey("tc_live__abcdef")).toBeNull()
+    expect(parseApiKey("tc_live_abcdef_")).toBeNull()
+  })
+
+  it("parses a valid key", () => {
+    const parsed = parseApiKey("tc_live_abcd1234_deadbeefcafe")
+    expect(parsed).toEqual({ prefix: "abcd1234", secret: "deadbeefcafe" })
+  })
+})
+
+describe("hashSecret", () => {
+  it("is deterministic", () => {
+    expect(hashSecret("hello")).toBe(hashSecret("hello"))
+  })
+
+  it("produces different hashes for different inputs", () => {
+    expect(hashSecret("a")).not.toBe(hashSecret("b"))
+  })
+})

--- a/src/lib/api-keys/auth.ts
+++ b/src/lib/api-keys/auth.ts
@@ -1,0 +1,121 @@
+import crypto from "crypto"
+import { NextResponse } from "next/server"
+import type { User } from "@prisma/client"
+import prisma from "@/lib/prisma"
+import { hashSecret, parseApiKey } from "./generate"
+import { checkRateLimit, RATE_LIMIT_PER_MINUTE } from "./rate-limit"
+
+export type AuthSource = "api-key" | "legacy-user-id"
+
+export interface AuthResult {
+  user: User
+  source: AuthSource
+  apiKeyId?: string
+  rateLimit?: { remaining: number; resetAt: Date }
+}
+
+const LEGACY_DEPRECATION_HEADER = `299 - "tc-legacy-api-key: pass an ApiKey from /dashboard/api-keys instead of your User ID; legacy auth will be removed in a future release"`
+
+// Authenticate an incoming `Authorization: Bearer <token>` header.
+//
+// Two acceptable token shapes:
+//   1. New: `tc_live_<prefix>_<secret>` — looks up ApiKey by prefix, verifies
+//      sha256(secret) with timing-safe compare, applies per-key rate limit.
+//   2. Legacy: a bare cuid that matches a User.id directly. README.md still
+//      documents this scheme, so we keep it working with a Warning header until
+//      we publish a deprecation timeline.
+//
+// Returns null on any failure (caller turns into 401). On success, the caller
+// should also forward `applyAuthResponseHeaders(response, result)` to surface
+// rate-limit headers and the legacy-deprecation Warning.
+export async function authenticateApiKey(req: Request): Promise<AuthResult | NextResponse> {
+  const auth = req.headers.get("Authorization")
+  if (!auth?.startsWith("Bearer ")) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  const token = auth.slice(7).trim()
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const parsed = parseApiKey(token)
+
+  // ── New-format key path ──
+  if (parsed) {
+    const apiKey = await prisma.apiKey.findUnique({ where: { prefix: parsed.prefix } })
+    if (!apiKey || apiKey.revokedAt) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+    if (apiKey.expiresAt && apiKey.expiresAt <= new Date()) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const candidateHash = hashSecret(parsed.secret)
+    const stored = Buffer.from(apiKey.hashedSecret, "hex")
+    const candidate = Buffer.from(candidateHash, "hex")
+    if (stored.length !== candidate.length || !crypto.timingSafeEqual(stored, candidate)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const rl = await checkRateLimit(apiKey.id)
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: "Rate limit exceeded" },
+        {
+          status: 429,
+          headers: {
+            "X-RateLimit-Limit": String(RATE_LIMIT_PER_MINUTE),
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": Math.floor(rl.resetAt.getTime() / 1000).toString(),
+            "Retry-After": Math.max(1, Math.ceil((rl.resetAt.getTime() - Date.now()) / 1000)).toString(),
+          },
+        }
+      )
+    }
+
+    const user = await prisma.user.findUnique({ where: { id: apiKey.userId } })
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    // fire-and-forget: lastUsedAt is observability, not correctness
+    prisma.apiKey
+      .update({ where: { id: apiKey.id }, data: { lastUsedAt: new Date() } })
+      .catch((e) => console.error("apiKey.lastUsedAt update failed:", e))
+
+    return {
+      user,
+      source: "api-key",
+      apiKeyId: apiKey.id,
+      rateLimit: { remaining: rl.remaining, resetAt: rl.resetAt },
+    }
+  }
+
+  // ── Legacy User.id-as-Bearer path ──
+  // README.md:79 documents this scheme. Keep it working but flag with Warning.
+  const user = await prisma.user.findUnique({ where: { id: token } })
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  return { user, source: "legacy-user-id" }
+}
+
+// Type guard — turns the union return into either the AuthResult or the
+// short-circuit response, in a shape that's easy to early-return at callsites.
+export function isAuthFailure(result: AuthResult | NextResponse): result is NextResponse {
+  return result instanceof NextResponse
+}
+
+// Decorates a successful response with rate-limit and (optionally) deprecation
+// headers, based on the AuthResult.
+export function applyAuthResponseHeaders(res: NextResponse, auth: AuthResult): NextResponse {
+  if (auth.rateLimit) {
+    res.headers.set("X-RateLimit-Limit", String(RATE_LIMIT_PER_MINUTE))
+    res.headers.set("X-RateLimit-Remaining", String(auth.rateLimit.remaining))
+    res.headers.set("X-RateLimit-Reset", Math.floor(auth.rateLimit.resetAt.getTime() / 1000).toString())
+  }
+  if (auth.source === "legacy-user-id") {
+    res.headers.set("Warning", LEGACY_DEPRECATION_HEADER)
+  }
+  return res
+}

--- a/src/lib/api-keys/generate.ts
+++ b/src/lib/api-keys/generate.ts
@@ -1,0 +1,44 @@
+import crypto from "crypto"
+
+export const KEY_PREFIX = "tc_live_"
+
+export interface GeneratedApiKey {
+  fullKey: string       // tc_live_<prefix>_<secret> — shown to user once, never stored
+  prefix: string        // 8 hex chars, stored on the row for display + lookup
+  hashedSecret: string  // sha256(secret) hex, stored on the row
+}
+
+// Mints a new API key. The full key is shown to the user once and never
+// retrievable; only the prefix and hash of the secret are persisted.
+export function generateApiKey(): GeneratedApiKey {
+  const prefix = crypto.randomBytes(4).toString("hex")  // 8 hex chars
+  const secret = crypto.randomBytes(32).toString("hex") // 64 hex chars
+  return {
+    fullKey: `${KEY_PREFIX}${prefix}_${secret}`,
+    prefix,
+    hashedSecret: hashSecret(secret),
+  }
+}
+
+export function hashSecret(secret: string): string {
+  return crypto.createHash("sha256").update(secret).digest("hex")
+}
+
+export interface ParsedApiKey {
+  prefix: string
+  secret: string
+}
+
+// Parses a full key like "tc_live_<prefix>_<secret>" into its parts. Returns
+// null for any string that doesn't match the format — used to fall through to
+// legacy User.id-as-Bearer auth.
+export function parseApiKey(key: string): ParsedApiKey | null {
+  if (!key.startsWith(KEY_PREFIX)) return null
+  const rest = key.slice(KEY_PREFIX.length)
+  const sep = rest.indexOf("_")
+  if (sep <= 0 || sep === rest.length - 1) return null
+  const prefix = rest.slice(0, sep)
+  const secret = rest.slice(sep + 1)
+  if (!/^[0-9a-f]+$/i.test(prefix) || !/^[0-9a-f]+$/i.test(secret)) return null
+  return { prefix, secret }
+}

--- a/src/lib/api-keys/rate-limit.ts
+++ b/src/lib/api-keys/rate-limit.ts
@@ -1,0 +1,39 @@
+import prisma from "@/lib/prisma"
+
+export const RATE_LIMIT_PER_MINUTE = 60
+
+// Truncates a Date to the start of its minute (UTC). Used as the bucket key
+// for the per-minute rate limiter.
+function windowStartFor(now: Date): Date {
+  const w = new Date(now)
+  w.setUTCSeconds(0, 0)
+  return w
+}
+
+export interface RateLimitResult {
+  allowed: boolean
+  remaining: number
+  resetAt: Date
+}
+
+// Atomically increments the counter for (apiKeyId, current minute) and returns
+// whether the request is allowed. Backed by ApiKeyUsage so it survives across
+// instances (Amplify can scale horizontally) without needing a shared cache.
+export async function checkRateLimit(apiKeyId: string, now = new Date()): Promise<RateLimitResult> {
+  const windowStart = windowStartFor(now)
+  const resetAt = new Date(windowStart.getTime() + 60_000)
+
+  const usage = await prisma.apiKeyUsage.upsert({
+    where: { apiKeyId_windowStart: { apiKeyId, windowStart } },
+    update: { count: { increment: 1 } },
+    create: { apiKeyId, windowStart, count: 1 },
+    select: { count: true },
+  })
+
+  const remaining = Math.max(0, RATE_LIMIT_PER_MINUTE - usage.count)
+  return {
+    allowed: usage.count <= RATE_LIMIT_PER_MINUTE,
+    remaining,
+    resetAt,
+  }
+}


### PR DESCRIPTION
## Summary
- New `ApiKey` model with `prefix` (8-hex public lookup) + `sha256(secret)` (stored hash). Full key shown once at creation; format: `tc_live_<prefix>_<secret>`
- New `authenticateApiKey()` helper in `src/lib/api-keys/auth.ts`. Wired into both `/api/v1/event-types` and `/api/v1/bookings`
- DB-backed per-key rate limit (60 req/min) via new `ApiKeyUsage` table — survives horizontal scaling on Amplify
- Legacy `User.id`-as-Bearer still works but returns `Warning: 299 - "tc-legacy-api-key"` header (README publicly documents the old scheme, so ripping out cleanly would break self-host users)
- `scripts/create-api-key.ts` for ops to mint keys until the dashboard UI ships
- README updated to document the new format, rate limit, and deprecation

## Why
Per #35: today the "API key" is literally `User.id`. Can't rotate, can't scope, leaked key leaks the primary identifier. Mira (the WhatsApp concierge in #33) needs a real credential before going live.

This is **PR1 of 2**. Dashboard UI (Settings → API Keys) is a follow-up so this can land and unblock the bot ASAP.

## Migration
`prisma/migrations/20260509000000_add_api_keys/migration.sql` adds `ApiKey` and `ApiKeyUsage` tables. Idempotent CREATE TABLEs only — no data backfill.

## Test plan
- [x] `npx vitest run src/lib/api-keys` — 22/22 pass (key gen, parse, hash, auth, rate-limit, revoked/expired, legacy fallback)
- [x] Full unit suite — 113/113 pass
- [ ] Apply migration on a preview DB
- [ ] `npx tsx scripts/create-api-key.ts <userEmail> "Mira"` produces a working key
- [ ] `curl -H "Authorization: Bearer tc_live_..." …/api/v1/event-types` returns 200
- [ ] Same call with a wrong secret returns 401
- [ ] Hammering past 60/min returns 429 with `Retry-After`
- [ ] Existing `Authorization: Bearer <user-id>` still works and includes the `Warning` header

Part of #33
Closes the backend portion of #35 (dashboard UI follow-up tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)