### PR TITLE
docs(webhooks): payload schema + normalize booking.* events

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Configure webhooks in the dashboard. Events:
 - `booking.cancelled`
 - `booking.rescheduled`
 
-Webhook payloads include `X-Webhook-Signature` header (HMAC-SHA256).
+Webhook payloads include `X-Webhook-Signature` header (HMAC-SHA256, bare hex).
+See [docs/webhooks.md](docs/webhooks.md) for the payload schema and signature
+verification examples.
 
 ## Deployment
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,140 @@
+# Webhooks
+
+TinyCal posts JSON to your configured webhook URLs whenever a booking is
+created, cancelled, or rescheduled. Each delivery is signed with HMAC-SHA256
+so you can verify it came from TinyCal.
+
+## Setup
+
+1. Go to **Dashboard → Webhooks**.
+2. Add a URL and select which events to subscribe to.
+3. Copy the auto-generated `secret` for that webhook — you'll use it to verify
+   the signature.
+
+## Delivery
+
+- **Method**: `POST`
+- **Headers**:
+  - `Content-Type: application/json`
+  - `X-Webhook-Signature: <hex>` — HMAC-SHA256 of the request body, hex-encoded.
+    **Note**: this is a bare hex string, not the `sha256=<hex>` format used by
+    GitHub/Stripe.
+
+### Request body
+
+```json
+{
+  "event": "booking.created",
+  "data": { ... },
+  "timestamp": "2026-05-09T15:30:00.000Z"
+}
+```
+
+`data` is the same shape across all `booking.*` events — see the
+[Payload reference](#payload-reference) below. `timestamp` is the moment
+TinyCal sent the webhook (not the booking time).
+
+### Retries
+
+Currently **none** — a delivery is attempted exactly once. Failed deliveries
+are logged on the server but not retried. Build receivers to be tolerant of
+duplicate or missed events; ack with a 2xx as soon as you've enqueued the work.
+
+## Verifying signatures
+
+The signature is `HMAC_SHA256(secret, raw_request_body)` as a lowercase hex
+string. Verify it against the **raw body bytes** before parsing JSON, since
+re-serializing parsed JSON can produce different bytes.
+
+### Node.js
+
+```ts
+import crypto from "crypto"
+
+function verify(rawBody: string, signatureHeader: string, secret: string): boolean {
+  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("hex")
+  const a = Buffer.from(expected, "hex")
+  const b = Buffer.from(signatureHeader, "hex")
+  return a.length === b.length && crypto.timingSafeEqual(a, b)
+}
+```
+
+### Python
+
+```python
+import hmac
+import hashlib
+
+def verify(raw_body: bytes, signature_header: str, secret: str) -> bool:
+    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+```
+
+## Events
+
+| Event                  | Trigger                                                             |
+|------------------------|---------------------------------------------------------------------|
+| `booking.created`      | A booking is created (booking page POST or meeting-link confirm)    |
+| `booking.cancelled`    | A booking is cancelled by booker or host                            |
+| `booking.rescheduled`  | A booking's start time changes; payload includes the previous time  |
+
+## Payload reference
+
+The `data` field of every `booking.*` event has this shape:
+
+```jsonc
+{
+  "booking": {
+    "id":          "ckabc123…",          // internal id
+    "uid":         "ckdef456…",          // public uid (used in /reschedule, /cancel URLs)
+    "status":      "CONFIRMED",          // PENDING | PENDING_CONFIRMATION | CONFIRMED | CANCELLED | RESCHEDULED | COMPLETED | NO_SHOW
+    "title":       "Discovery call",
+    "startTime":   "2026-06-01T15:00:00.000Z",  // ISO 8601 UTC
+    "endTime":     "2026-06-01T15:30:00.000Z",
+    "location":    "GOOGLE_MEET",        // GOOGLE_MEET | ZOOM | IN_PERSON | PHONE | CUSTOM
+    "meetingUrl":  "https://meet.google.com/abc-defg-hij",  // null for IN_PERSON/PHONE
+    "source":      "BOOKING_PAGE",       // BOOKING_PAGE | MEETING_LINK
+    "booker": {
+      "name":      "Alex Doe",
+      "email":     "alex@example.com",
+      "timezone":  "America/Los_Angeles",
+      "phone":     "+15551234567"        // null if not collected
+    },
+    "answers":     { "q_1": "..." },     // booker's answers to custom questions; null if none
+    "cancelReason": null,                // populated for booking.cancelled if booker provided one
+    "confirmedAt":  null,                // ISO timestamp; populated for MEETING_LINK bookings on confirm
+    "createdAt":    "2026-05-09T15:25:00.000Z"
+  },
+  "eventType": {
+    "id":           "ckxyz789…",
+    "slug":         "discovery-call",
+    "title":        "Discovery call",
+    "duration":     30,                  // minutes
+    "isCollective": true                 // true if multiple hosts must be available
+  },
+  "host": {
+    "id":    "ckhost123…",
+    "name":  "Sze",
+    "email": "sze@example.com"
+  },
+
+  // booking.rescheduled only:
+  "previous": {
+    "startTime": "2026-06-01T14:00:00.000Z",
+    "endTime":   "2026-06-01T14:30:00.000Z"
+  }
+}
+```
+
+### Notes
+
+- All datetimes are ISO 8601 with explicit UTC offset (`Z`). Use the
+  `booker.timezone` field to render local times for the booker.
+- For collective event types, the `host` field is the *event-type owner*, not
+  every co-host. If you need every host's email, fetch the event type via
+  `/api/v1/event-types?slug=<slug>` and read `collectiveMembers`.
+- `answers` is opaque to the schema — the keys come from the custom-question
+  IDs configured on the event type. To resolve them to question labels, fetch
+  the event type's `questions` via the API.
+- Internal fields (Stripe payment intent IDs, raw token data) are deliberately
+  excluded from webhook payloads.

--- a/src/app/api/bookings/[uid]/cancel/route.ts
+++ b/src/app/api/bookings/[uid]/cancel/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma"
 import { sendEmail, bookingCancelledEmail } from "@/lib/email"
 import { deleteGoogleCalendarEvent } from "@/lib/calendar/google"
 import { triggerWebhooks } from "@/lib/webhooks"
+import { buildBookingPayload } from "@/lib/webhooks/booking-payload"
 import { format } from "date-fns"
 import { toZonedTime } from "date-fns-tz"
 
@@ -57,7 +58,8 @@ export async function POST(req: Request, { params }: { params: { uid: string } }
     console.error("Cancel email failed:", e)
   }
 
-  await triggerWebhooks(booking.userId, "booking.cancelled", booking)
+  const payload = await buildBookingPayload(booking.id)
+  if (payload) await triggerWebhooks(booking.userId, "booking.cancelled", payload)
 
   return NextResponse.json({ success: true })
 }

--- a/src/app/api/bookings/[uid]/reschedule/route.ts
+++ b/src/app/api/bookings/[uid]/reschedule/route.ts
@@ -4,6 +4,7 @@ import { sendEmail, bookingConfirmationEmail } from "@/lib/email"
 import { updateGoogleCalendarEvent, createGoogleCalendarEvent } from "@/lib/calendar/google"
 import { updateOutlookCalendarEvent, createOutlookCalendarEvent } from "@/lib/calendar/outlook"
 import { triggerWebhooks } from "@/lib/webhooks"
+import { buildBookingPayload } from "@/lib/webhooks/booking-payload"
 import { format } from "date-fns"
 import { toZonedTime } from "date-fns-tz"
 
@@ -176,7 +177,11 @@ export async function POST(req: Request, { params }: { params: { uid: string } }
     console.error("Host reschedule email failed:", e)
   }
 
-  await triggerWebhooks(booking.userId, "booking.rescheduled", { old: booking, new: updatedBooking })
+  const payload = await buildBookingPayload(booking.id, {
+    previousStartTime: booking.startTime,
+    previousEndTime: booking.endTime,
+  })
+  if (payload) await triggerWebhooks(booking.userId, "booking.rescheduled", payload)
 
   return NextResponse.json({
     ...updatedBooking,

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -6,6 +6,7 @@ import { createGoogleCalendarEvent } from "@/lib/calendar/google"
 import { createOutlookCalendarEvent } from "@/lib/calendar/outlook"
 import { createZoomMeeting } from "@/lib/video"
 import { triggerWebhooks } from "@/lib/webhooks"
+import { buildBookingPayload } from "@/lib/webhooks/booking-payload"
 import { format } from "date-fns"
 import { toZonedTime } from "date-fns-tz"
 
@@ -155,7 +156,8 @@ export async function POST(req: Request) {
     }
 
     // Trigger webhooks
-    await triggerWebhooks(eventType.userId, "booking.created", booking)
+    const payload = await buildBookingPayload(booking.id)
+    if (payload) await triggerWebhooks(eventType.userId, "booking.created", payload)
 
     // Also create calendar event in Outlook if connected
     if (eventType.location !== "GOOGLE_MEET") {

--- a/src/app/api/meeting-links/[uid]/confirm/route.ts
+++ b/src/app/api/meeting-links/[uid]/confirm/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import prisma from "@/lib/prisma"
 import { sendEmail, bookingConfirmationEmail } from "@/lib/email"
 import { triggerWebhooks } from "@/lib/webhooks"
+import { buildBookingPayload } from "@/lib/webhooks/booking-payload"
 import { createGoogleCalendarEvent, updateGoogleCalendarEvent } from "@/lib/calendar/google"
 import { createOutlookCalendarEvent, updateOutlookCalendarEvent } from "@/lib/calendar/outlook"
 import { format } from "date-fns"
@@ -197,7 +198,8 @@ export async function POST(req: Request, { params }: { params: { uid: string } }
     }
 
     // Trigger webhooks
-    await triggerWebhooks(booking.userId, "booking.created", updatedBooking)
+    const payload = await buildBookingPayload(updatedBooking.id)
+    if (payload) await triggerWebhooks(booking.userId, "booking.created", payload)
 
     return NextResponse.json(updatedBooking)
   } catch (error) {

--- a/src/lib/webhooks/__tests__/booking-payload.test.ts
+++ b/src/lib/webhooks/__tests__/booking-payload.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { buildBookingPayload } from "../booking-payload"
+
+const mockBookingFindUnique = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    booking: {
+      findUnique: (...args: any[]) => mockBookingFindUnique(...args),
+    },
+  },
+}))
+
+const SAMPLE_BOOKING = {
+  id: "bk-1",
+  uid: "uid-1",
+  status: "CONFIRMED",
+  title: "Discovery",
+  startTime: new Date("2026-06-01T15:00:00Z"),
+  endTime: new Date("2026-06-01T15:30:00Z"),
+  location: "GOOGLE_MEET",
+  meetingUrl: "https://meet.google.com/abc",
+  source: "BOOKING_PAGE",
+  bookerName: "Alex",
+  bookerEmail: "alex@example.com",
+  bookerTimezone: "America/Los_Angeles",
+  bookerPhone: "+15551234567",
+  answers: { q_1: "answer" },
+  cancelReason: null,
+  confirmedAt: null,
+  createdAt: new Date("2026-05-09T15:25:00Z"),
+  eventType: {
+    id: "et-1",
+    slug: "discovery",
+    title: "Discovery",
+    duration: 30,
+    isCollective: true,
+    user: { id: "host-1", name: "Sze", email: "sze@example.com" },
+  },
+}
+
+describe("buildBookingPayload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns null for an unknown bookingId", async () => {
+    mockBookingFindUnique.mockResolvedValue(null)
+    expect(await buildBookingPayload("missing")).toBeNull()
+  })
+
+  it("includes eventType slug+title and host info", async () => {
+    mockBookingFindUnique.mockResolvedValue(SAMPLE_BOOKING)
+    const payload = await buildBookingPayload("bk-1")
+
+    expect(payload).not.toBeNull()
+    expect(payload!.eventType).toEqual({
+      id: "et-1",
+      slug: "discovery",
+      title: "Discovery",
+      duration: 30,
+      isCollective: true,
+    })
+    expect(payload!.host).toEqual({
+      id: "host-1",
+      name: "Sze",
+      email: "sze@example.com",
+    })
+  })
+
+  it("serializes dates as ISO 8601 UTC", async () => {
+    mockBookingFindUnique.mockResolvedValue(SAMPLE_BOOKING)
+    const payload = await buildBookingPayload("bk-1")
+
+    expect(payload!.booking.startTime).toBe("2026-06-01T15:00:00.000Z")
+    expect(payload!.booking.endTime).toBe("2026-06-01T15:30:00.000Z")
+    expect(payload!.booking.createdAt).toBe("2026-05-09T15:25:00.000Z")
+  })
+
+  it("includes booker phone, answers, and source", async () => {
+    mockBookingFindUnique.mockResolvedValue(SAMPLE_BOOKING)
+    const payload = await buildBookingPayload("bk-1")
+
+    expect(payload!.booking.booker).toEqual({
+      name: "Alex",
+      email: "alex@example.com",
+      timezone: "America/Los_Angeles",
+      phone: "+15551234567",
+    })
+    expect(payload!.booking.answers).toEqual({ q_1: "answer" })
+    expect(payload!.booking.source).toBe("BOOKING_PAGE")
+  })
+
+  it("does NOT include the previous block when previous times aren't passed", async () => {
+    mockBookingFindUnique.mockResolvedValue(SAMPLE_BOOKING)
+    const payload = await buildBookingPayload("bk-1")
+    expect(payload!.previous).toBeUndefined()
+  })
+
+  it("includes previous block for booking.rescheduled", async () => {
+    mockBookingFindUnique.mockResolvedValue(SAMPLE_BOOKING)
+    const payload = await buildBookingPayload("bk-1", {
+      previousStartTime: new Date("2026-06-01T14:00:00Z"),
+      previousEndTime: new Date("2026-06-01T14:30:00Z"),
+    })
+    expect(payload!.previous).toEqual({
+      startTime: "2026-06-01T14:00:00.000Z",
+      endTime: "2026-06-01T14:30:00.000Z",
+    })
+  })
+
+  it("does NOT leak internal fields (stripePaymentIntentId, meetingId)", async () => {
+    mockBookingFindUnique.mockResolvedValue({
+      ...SAMPLE_BOOKING,
+      stripePaymentIntentId: "pi_secret",
+      meetingId: "internal-id",
+    })
+    const payload = await buildBookingPayload("bk-1")
+    expect(JSON.stringify(payload)).not.toContain("pi_secret")
+    expect(JSON.stringify(payload)).not.toContain("internal-id")
+  })
+
+  it("handles nulls for optional fields (phone, answers, cancelReason)", async () => {
+    mockBookingFindUnique.mockResolvedValue({
+      ...SAMPLE_BOOKING,
+      bookerPhone: null,
+      answers: null,
+      cancelReason: null,
+    })
+    const payload = await buildBookingPayload("bk-1")
+    expect(payload!.booking.booker.phone).toBeNull()
+    expect(payload!.booking.answers).toBeNull()
+    expect(payload!.booking.cancelReason).toBeNull()
+  })
+})

--- a/src/lib/webhooks/booking-payload.ts
+++ b/src/lib/webhooks/booking-payload.ts
@@ -1,0 +1,114 @@
+import prisma from "@/lib/prisma"
+
+// Stable, public-facing payload shape for booking.* webhook events.
+// Strips internal fields (Stripe IDs, raw DB metadata) and ensures every event
+// includes eventType + host info — callers like the Mira concierge bot rely on
+// these being present without having to make a second API call.
+export interface BookingWebhookPayload {
+  booking: {
+    id: string
+    uid: string
+    status: string
+    title: string
+    startTime: string  // ISO 8601 UTC
+    endTime: string    // ISO 8601 UTC
+    location: string
+    meetingUrl: string | null
+    source: string
+    booker: {
+      name: string
+      email: string
+      timezone: string
+      phone: string | null
+    }
+    answers: unknown
+    cancelReason: string | null
+    confirmedAt: string | null
+    createdAt: string
+  }
+  eventType: {
+    id: string
+    slug: string
+    title: string
+    duration: number
+    isCollective: boolean
+  }
+  host: {
+    id: string
+    name: string | null
+    email: string | null
+  }
+  previous?: {
+    startTime: string
+    endTime: string
+  }
+}
+
+interface BuildOptions {
+  previousStartTime?: Date
+  previousEndTime?: Date
+}
+
+// Fetches a booking by id and shapes it into the stable webhook payload.
+// Returns null if the booking has been deleted by the time we get here (which
+// shouldn't normally happen, but webhook fanout is async so we tolerate it).
+export async function buildBookingPayload(
+  bookingId: string,
+  opts: BuildOptions = {}
+): Promise<BookingWebhookPayload | null> {
+  const booking = await prisma.booking.findUnique({
+    where: { id: bookingId },
+    include: {
+      eventType: {
+        include: { user: { select: { id: true, name: true, email: true } } },
+      },
+    },
+  })
+
+  if (!booking) return null
+
+  const payload: BookingWebhookPayload = {
+    booking: {
+      id: booking.id,
+      uid: booking.uid,
+      status: booking.status,
+      title: booking.title,
+      startTime: booking.startTime.toISOString(),
+      endTime: booking.endTime.toISOString(),
+      location: booking.location,
+      meetingUrl: booking.meetingUrl,
+      source: booking.source,
+      booker: {
+        name: booking.bookerName,
+        email: booking.bookerEmail,
+        timezone: booking.bookerTimezone,
+        phone: booking.bookerPhone,
+      },
+      answers: booking.answers,
+      cancelReason: booking.cancelReason,
+      confirmedAt: booking.confirmedAt?.toISOString() ?? null,
+      createdAt: booking.createdAt.toISOString(),
+    },
+    eventType: {
+      id: booking.eventType.id,
+      slug: booking.eventType.slug,
+      title: booking.eventType.title,
+      duration: booking.eventType.duration,
+      isCollective: booking.eventType.isCollective,
+    },
+    host: {
+      id: booking.eventType.user.id,
+      name: booking.eventType.user.name,
+      email: booking.eventType.user.email,
+    },
+  }
+
+  if (opts.previousStartTime && opts.previousEndTime) {
+    payload.previous = {
+      startTime: opts.previousStartTime.toISOString(),
+      endTime: opts.previousEndTime.toISOString(),
+    }
+  }
+
+  return payload
+}


### PR DESCRIPTION
## Summary
- New `docs/webhooks.md` with full payload schema for `booking.created`/`cancelled`/`rescheduled`, signature verification examples (Node + Python), and a callout that the signature is bare hex (not `sha256=` prefixed)
- New `src/lib/webhooks/booking-payload.ts` that fetches the booking with `eventType + host` includes and emits a stable shape, replacing the inconsistent payloads each callsite was passing in
- All 4 trigger sites (bookings POST, cancel, reschedule, meeting-links confirm) updated to use the helper

## Why
Per #38: anyone consuming `booking.created` had to make a second API call to get the eventType slug/title or the host's email, because the trigger site only passed in the bare booking row. This was even more broken on `booking.rescheduled` where `updatedBooking` was a `prisma.update()` result with no relations loaded.

The normalized payload also strips internal fields (Stripe payment intent IDs, raw meeting IDs) that were leaking into webhooks before.

The signature format stays bare hex — switching to `sha256=<hex>` would silently break any existing receiver.

## Test plan
- [x] `npx vitest run src/lib/webhooks` — 8/8 pass
- [x] Full unit suite — 99/99 pass
- [ ] Send a test booking → verify webhook payload matches docs (eventType slug, host email present, no Stripe IDs)
- [ ] Reschedule it → verify `previous` block populated

Closes #38
Part of #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)