### PR TITLE
feat(api/v1): support ?slug= filter on GET /api/v1/event-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Per-key rate limit: **60 requests/minute**. Responses include
 > be removed in a future release — migrate to a real API key.
 
 #### Event Types
-- `GET /api/v1/event-types` — List all event types
+- `GET /api/v1/event-types` — List all event types (supports `?slug=<slug>` filter)
 - `POST /api/v1/event-types` — Create event type
 
 #### Bookings

--- a/src/__tests__/api/v1-event-types.test.ts
+++ b/src/__tests__/api/v1-event-types.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockEventTypeFindMany = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    eventType: {
+      findMany: (...args: any[]) => mockEventTypeFindMany(...args),
+      create: vi.fn(),
+    },
+  },
+}))
+
+const TEST_USER = { id: "user-1", email: "x@y.z", name: "X" } as any
+
+vi.mock("@/lib/api-keys/auth", () => ({
+  authenticateApiKey: vi.fn(async () => ({
+    user: TEST_USER,
+    source: "api-key",
+    apiKeyId: "ak-1",
+    rateLimit: { remaining: 59, resetAt: new Date(Date.now() + 60000) },
+  })),
+  isAuthFailure: () => false,
+  applyAuthResponseHeaders: (res: any) => res,
+}))
+
+import { GET } from "@/app/api/v1/event-types/route"
+
+describe("GET /api/v1/event-types", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEventTypeFindMany.mockResolvedValue([])
+  })
+
+  it("returns all event types when no slug filter is provided", async () => {
+    await GET(new Request("http://localhost/api/v1/event-types"))
+
+    expect(mockEventTypeFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: TEST_USER.id },
+      })
+    )
+  })
+
+  it("filters by slug when ?slug= is passed", async () => {
+    await GET(new Request("http://localhost/api/v1/event-types?slug=discovery-call"))
+
+    expect(mockEventTypeFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: TEST_USER.id, slug: "discovery-call" },
+      })
+    )
+  })
+
+  it("returns the standard { data: [...] } shape", async () => {
+    const sample = { id: "et-1", slug: "discovery-call", title: "Discovery" }
+    mockEventTypeFindMany.mockResolvedValueOnce([sample])
+
+    const res = await GET(new Request("http://localhost/api/v1/event-types?slug=discovery-call"))
+    const body = await res.json()
+    expect(body).toEqual({ data: [sample] })
+  })
+
+  it("returns an empty array (not 404) when slug doesn't match", async () => {
+    mockEventTypeFindMany.mockResolvedValueOnce([])
+
+    const res = await GET(new Request("http://localhost/api/v1/event-types?slug=nope"))
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ data: [] })
+  })
+})

--- a/src/app/api/v1/event-types/route.ts
+++ b/src/app/api/v1/event-types/route.ts
@@ -6,8 +6,13 @@ export async function GET(req: Request) {
   const auth = await authenticateApiKey(req)
   if (isAuthFailure(auth)) return auth
 
+  const slug = new URL(req.url).searchParams.get("slug")
+
   const eventTypes = await prisma.eventType.findMany({
-    where: { userId: auth.user.id },
+    where: {
+      userId: auth.user.id,
+      ...(slug && { slug }),
+    },
     include: { questions: true, _count: { select: { bookings: true } } },
   })
   return applyAuthResponseHeaders(NextResponse.json({ data: eventTypes }), auth)


### PR DESCRIPTION
## Summary
- Adds `?slug=<slug>` query-string filter to `GET /api/v1/event-types`
- 4 unit tests covering: no filter, with filter, response shape, empty result (200, not 404)
- README API table updated

## Why
Per #37: the Mira concierge bot references event types by slug, not DB id. Filtering server-side keeps the bot from caching IDs or paginating through a full list to find one row. `@@unique([userId, slug])` makes it a single-row index lookup.

## Test plan
- [x] `npx vitest run src/__tests__/api/v1-event-types` — 4/4 pass
- [x] Full suite — 134/134 pass
- [ ] `curl -H "Authorization: Bearer tc_live_..." ".../api/v1/event-types?slug=discovery-call"` returns just that event type
- [ ] Same call with a non-existent slug returns `{ data: [] }` and 200

Closes #37
Part of #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)