### PR TITLE
feat(api/v1): POST /api/v1/bookings via shared createBooking() lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Per-key rate limit: **60 requests/minute**. Responses include
 
 #### Bookings
 - `GET /api/v1/bookings` — List bookings (supports `?status=`, `?from=`, `?to=` filters)
+- `POST /api/v1/bookings` — Create a booking on one of your event types. Body: `{ eventTypeId, startTime (ISO 8601), bookerName, bookerEmail, bookerTimezone, bookerPhone?, answers? }`. Returns `201` with `{ data: <booking> }` including `meetingUrl`. The event type must belong to the API key's owner (otherwise `403`).
 
 #### Calendar Connections
 - `PATCH /api/calendar-connections/:id` — Update connection settings (label, checkConflicts, isPrimary)

--- a/src/__tests__/api/v1-bookings.test.ts
+++ b/src/__tests__/api/v1-bookings.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockBookingFindMany = vi.fn()
+const mockCreateBooking = vi.fn()
+const mockAuthenticateApiKey = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    booking: { findMany: (...args: any[]) => mockBookingFindMany(...args) },
+  },
+}))
+
+vi.mock("@/lib/bookings/create", () => ({
+  createBooking: (...args: any[]) => mockCreateBooking(...args),
+}))
+
+vi.mock("@/lib/api-keys/auth", () => ({
+  authenticateApiKey: (...args: any[]) => mockAuthenticateApiKey(...args),
+  isAuthFailure: (r: any) =>
+    r &&
+    typeof r === "object" &&
+    "status" in r &&
+    typeof r.status === "number" &&
+    "headers" in r,
+  applyAuthResponseHeaders: (res: any) => res,
+}))
+
+import { POST } from "@/app/api/v1/bookings/route"
+
+const TEST_USER = { id: "user-1", email: "x@y.z", name: "X" } as any
+const VALID_BODY = {
+  eventTypeId: "et-1",
+  startTime: "2026-06-01T15:00:00.000Z",
+  bookerName: "Alex",
+  bookerEmail: "alex@example.com",
+  bookerTimezone: "America/Los_Angeles",
+}
+
+function makePostReq(body: unknown): Request {
+  return new Request("http://localhost/api/v1/bookings", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Bearer fake" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  })
+}
+
+describe("POST /api/v1/bookings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthenticateApiKey.mockResolvedValue({
+      user: TEST_USER,
+      source: "api-key",
+      apiKeyId: "ak-1",
+      rateLimit: { remaining: 59, resetAt: new Date() },
+    })
+    mockCreateBooking.mockResolvedValue({
+      ok: true,
+      booking: { id: "bk-1", meetingUrl: "https://meet/x" },
+    })
+  })
+
+  describe("auth", () => {
+    it("returns whatever authenticateApiKey returns on failure (401)", async () => {
+      const failure = new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      })
+      mockAuthenticateApiKey.mockResolvedValueOnce(failure)
+      const res = await POST(makePostReq(VALID_BODY))
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe("validation", () => {
+    it("rejects malformed JSON", async () => {
+      const res = await POST(makePostReq("{not-json"))
+      expect(res.status).toBe(400)
+    })
+
+    it("rejects missing required fields", async () => {
+      const res = await POST(makePostReq({ eventTypeId: "et-1" }))
+      expect(res.status).toBe(400)
+      expect(mockCreateBooking).not.toHaveBeenCalled()
+    })
+
+    it("rejects non-ISO startTime", async () => {
+      const res = await POST(makePostReq({ ...VALID_BODY, startTime: "tomorrow at 3pm" }))
+      expect(res.status).toBe(400)
+    })
+
+    it("rejects invalid bookerEmail", async () => {
+      const res = await POST(makePostReq({ ...VALID_BODY, bookerEmail: "not-an-email" }))
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe("ownership", () => {
+    it("passes requireOwnerUserId = auth.user.id to createBooking", async () => {
+      await POST(makePostReq(VALID_BODY))
+      expect(mockCreateBooking).toHaveBeenCalledWith(
+        expect.objectContaining({ requireOwnerUserId: TEST_USER.id })
+      )
+    })
+
+    it("returns 403 when createBooking reports FORBIDDEN", async () => {
+      mockCreateBooking.mockResolvedValueOnce({ ok: false, error: "FORBIDDEN", status: 403 })
+      const res = await POST(makePostReq(VALID_BODY))
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe("error mapping", () => {
+    it("returns 404 for EVENT_TYPE_NOT_FOUND", async () => {
+      mockCreateBooking.mockResolvedValueOnce({
+        ok: false,
+        error: "EVENT_TYPE_NOT_FOUND",
+        status: 404,
+      })
+      const res = await POST(makePostReq(VALID_BODY))
+      expect(res.status).toBe(404)
+    })
+
+    it("returns 409 for CONFLICT", async () => {
+      mockCreateBooking.mockResolvedValueOnce({ ok: false, error: "CONFLICT", status: 409 })
+      const res = await POST(makePostReq(VALID_BODY))
+      expect(res.status).toBe(409)
+    })
+  })
+
+  describe("happy path", () => {
+    it("returns 201 with the created booking under data.", async () => {
+      const res = await POST(makePostReq(VALID_BODY))
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body).toEqual({ data: { id: "bk-1", meetingUrl: "https://meet/x" } })
+    })
+  })
+})

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -1,15 +1,7 @@
 import { NextResponse } from "next/server"
 import { getAuthenticatedUser } from "@/lib/auth"
 import prisma from "@/lib/prisma"
-import { sendEmail, bookingConfirmationEmail } from "@/lib/email"
-import { createGoogleCalendarEvent } from "@/lib/calendar/google"
-import { createOutlookCalendarEvent } from "@/lib/calendar/outlook"
-import { createZoomMeeting } from "@/lib/video"
-import { triggerWebhooks } from "@/lib/webhooks"
-import { buildBookingPayload } from "@/lib/webhooks/booking-payload"
-import { hasBookingConflict } from "@/lib/bookings/conflict-check"
-import { format } from "date-fns"
-import { toZonedTime } from "date-fns-tz"
+import { createBooking } from "@/lib/bookings/create"
 
 export async function GET() {
   const user = await getAuthenticatedUser()
@@ -27,147 +19,26 @@ export async function GET() {
 export async function POST(req: Request) {
   try {
     const body = await req.json()
-    const { eventTypeId, startTime, bookerName, bookerEmail, bookerTimezone, bookerPhone, answers } = body
-
-    const eventType = await prisma.eventType.findUnique({
-      where: { id: eventTypeId },
-      include: { user: true },
-    })
-    if (!eventType) return NextResponse.json({ error: "Event type not found" }, { status: 404 })
-
-    const start = new Date(startTime)
-    const end = new Date(start.getTime() + eventType.duration * 60000)
-
-    if (await hasBookingConflict({ eventType, start, end })) {
-      return NextResponse.json({ error: "Time slot no longer available" }, { status: 409 })
-    }
-
-    // Generate meeting link
-    let meetingUrl: string | undefined
-    let meetingId: string | undefined
-
-    if (eventType.location === "GOOGLE_MEET") {
-      const calEvent = await createGoogleCalendarEvent(eventType.userId, {
-        summary: `${eventType.title} - ${bookerName}`,
-        description: `Booked via TinyCal`,
-        startTime: start,
-        endTime: end,
-        attendees: [{ email: bookerEmail }],
-        conferenceData: true,
-      })
-      meetingUrl = calEvent?.meetingUrl || undefined
-      meetingId = calEvent?.id || undefined
-    } else if (eventType.location === "ZOOM") {
-      const zoom = await createZoomMeeting({
-        topic: `${eventType.title} - ${bookerName}`,
-        startTime: start,
-        duration: eventType.duration,
-      })
-      meetingUrl = zoom?.url
-      meetingId = zoom?.id
-    }
-
-    // Create booking
-    const booking = await prisma.booking.create({
-      data: {
-        eventTypeId,
-        userId: eventType.userId,
-        title: eventType.title,
-        startTime: start,
-        endTime: end,
-        bookerName,
-        bookerEmail,
-        bookerTimezone,
-        bookerPhone,
-        location: eventType.location,
-        meetingUrl,
-        meetingId,
-        answers,
-        status: eventType.requirePayment ? "PENDING" : "CONFIRMED",
-      },
+    const result = await createBooking({
+      eventTypeId: body.eventTypeId,
+      startTime: body.startTime,
+      bookerName: body.bookerName,
+      bookerEmail: body.bookerEmail,
+      bookerTimezone: body.bookerTimezone,
+      bookerPhone: body.bookerPhone,
+      answers: body.answers,
     })
 
-    // Create/update contact
-    await prisma.contact.upsert({
-      where: { userId_email: { userId: eventType.userId, email: bookerEmail } },
-      update: { name: bookerName, phone: bookerPhone },
-      create: {
-        userId: eventType.userId,
-        name: bookerName,
-        email: bookerEmail,
-        phone: bookerPhone,
-        source: "booking",
-      },
-    })
-
-    // Send confirmation emails
-    const zonedStart = toZonedTime(start, bookerTimezone)
-    const dateTimeStr = format(zonedStart, "EEEE, MMMM d, yyyy 'at' h:mm a")
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL!
-
-    try {
-      await sendEmail({
-        to: bookerEmail,
-        subject: `Confirmed: ${eventType.title} with ${eventType.user.name}`,
-        html: bookingConfirmationEmail({
-          bookerName,
-          hostName: eventType.user.name || "Host",
-          eventTitle: eventType.title,
-          dateTime: dateTimeStr,
-          timezone: bookerTimezone,
-          location: eventType.location,
-          meetingUrl,
-          rescheduleUrl: `${appUrl}/reschedule/${booking.uid}`,
-          cancelUrl: `${appUrl}/cancel/${booking.uid}`,
-        }),
-      })
-    } catch (e) {
-      console.error("Email send failed:", e)
-    }
-
-    // Email to host
-    try {
-      if (eventType.user.email) {
-        await sendEmail({
-          to: eventType.user.email,
-          subject: `New booking: ${eventType.title} with ${bookerName}`,
-          html: bookingConfirmationEmail({
-            bookerName: eventType.user.name || "Host",
-            hostName: bookerName,
-            eventTitle: eventType.title,
-            dateTime: dateTimeStr,
-            timezone: bookerTimezone,
-            location: eventType.location,
-            meetingUrl,
-            rescheduleUrl: `${appUrl}/reschedule/${booking.uid}`,
-            cancelUrl: `${appUrl}/cancel/${booking.uid}`,
-          }),
-        })
+    if (!result.ok) {
+      const messages: Record<typeof result.error, string> = {
+        EVENT_TYPE_NOT_FOUND: "Event type not found",
+        FORBIDDEN: "Forbidden",
+        CONFLICT: "Time slot no longer available",
       }
-    } catch (e) {
-      console.error("Host email send failed:", e)
+      return NextResponse.json({ error: messages[result.error] }, { status: result.status })
     }
 
-    // Trigger webhooks
-    const payload = await buildBookingPayload(booking.id)
-    if (payload) await triggerWebhooks(eventType.userId, "booking.created", payload)
-
-    // Also create calendar event in Outlook if connected
-    if (eventType.location !== "GOOGLE_MEET") {
-      const outlookConn = await prisma.calendarConnection.findFirst({
-        where: { userId: eventType.userId, provider: "OUTLOOK" },
-      })
-      if (outlookConn) {
-        await createOutlookCalendarEvent(eventType.userId, {
-          summary: `${eventType.title} - ${bookerName}`,
-          startTime: start,
-          endTime: end,
-          attendees: [{ email: bookerEmail }],
-        })
-      }
-    }
-
-    return NextResponse.json(booking)
+    return NextResponse.json(result.booking)
   } catch (error) {
     console.error("Booking creation error:", error)
     return NextResponse.json({ error: "Booking failed" }, { status: 500 })

--- a/src/app/api/v1/bookings/route.ts
+++ b/src/app/api/v1/bookings/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
+import { z } from "zod"
 import prisma from "@/lib/prisma"
 import { authenticateApiKey, isAuthFailure, applyAuthResponseHeaders } from "@/lib/api-keys/auth"
+import { createBooking } from "@/lib/bookings/create"
 
 export async function GET(req: Request) {
   const auth = await authenticateApiKey(req)
@@ -23,4 +25,56 @@ export async function GET(req: Request) {
     take: 100,
   })
   return applyAuthResponseHeaders(NextResponse.json({ data: bookings }), auth)
+}
+
+const PostBodySchema = z.object({
+  eventTypeId: z.string().min(1),
+  startTime: z.string().datetime(),
+  bookerName: z.string().min(1),
+  bookerEmail: z.string().email(),
+  bookerTimezone: z.string().min(1),
+  bookerPhone: z.string().nullish(),
+  answers: z.unknown().nullish(),
+})
+
+export async function POST(req: Request) {
+  const auth = await authenticateApiKey(req)
+  if (isAuthFailure(auth)) return auth
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const parsed = PostBodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid body", details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const result = await createBooking({
+    ...parsed.data,
+    requireOwnerUserId: auth.user.id,
+  })
+
+  if (!result.ok) {
+    const messages: Record<typeof result.error, string> = {
+      EVENT_TYPE_NOT_FOUND: "Event type not found",
+      FORBIDDEN: "Event type does not belong to this API key's owner",
+      CONFLICT: "Time slot no longer available",
+    }
+    return applyAuthResponseHeaders(
+      NextResponse.json({ error: messages[result.error] }, { status: result.status }),
+      auth
+    )
+  }
+
+  return applyAuthResponseHeaders(
+    NextResponse.json({ data: result.booking }, { status: 201 }),
+    auth
+  )
 }

--- a/src/lib/bookings/__tests__/create.test.ts
+++ b/src/lib/bookings/__tests__/create.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { createBooking } from "../create"
+
+const mockEventTypeFindUnique = vi.fn()
+const mockBookingCreate = vi.fn()
+const mockContactUpsert = vi.fn()
+const mockCalendarConnectionFindFirst = vi.fn()
+const mockHasBookingConflict = vi.fn()
+const mockCreateGoogleCalendarEvent = vi.fn()
+const mockCreateZoomMeeting = vi.fn()
+const mockCreateOutlookCalendarEvent = vi.fn()
+const mockSendEmail = vi.fn()
+const mockTriggerWebhooks = vi.fn()
+const mockBuildBookingPayload = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    eventType: { findUnique: (...args: any[]) => mockEventTypeFindUnique(...args) },
+    booking: { create: (...args: any[]) => mockBookingCreate(...args) },
+    contact: { upsert: (...args: any[]) => mockContactUpsert(...args) },
+    calendarConnection: { findFirst: (...args: any[]) => mockCalendarConnectionFindFirst(...args) },
+  },
+}))
+
+vi.mock("@/lib/bookings/conflict-check", () => ({
+  hasBookingConflict: (...args: any[]) => mockHasBookingConflict(...args),
+}))
+
+vi.mock("@/lib/calendar/google", () => ({
+  createGoogleCalendarEvent: (...args: any[]) => mockCreateGoogleCalendarEvent(...args),
+}))
+
+vi.mock("@/lib/calendar/outlook", () => ({
+  createOutlookCalendarEvent: (...args: any[]) => mockCreateOutlookCalendarEvent(...args),
+}))
+
+vi.mock("@/lib/video", () => ({
+  createZoomMeeting: (...args: any[]) => mockCreateZoomMeeting(...args),
+}))
+
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: any[]) => mockSendEmail(...args),
+  bookingConfirmationEmail: () => "<html>",
+}))
+
+vi.mock("@/lib/webhooks", () => ({
+  triggerWebhooks: (...args: any[]) => mockTriggerWebhooks(...args),
+}))
+
+vi.mock("@/lib/webhooks/booking-payload", () => ({
+  buildBookingPayload: (...args: any[]) => mockBuildBookingPayload(...args),
+}))
+
+const HOST = { id: "host-1", name: "Sze", email: "sze@example.com" }
+const SOLO_EVENT_TYPE = {
+  id: "et-1",
+  userId: "host-1",
+  title: "Discovery",
+  slug: "discovery",
+  duration: 30,
+  location: "GOOGLE_MEET",
+  isCollective: false,
+  collectiveMembers: [],
+  requirePayment: false,
+  user: HOST,
+} as any
+
+const VALID_INPUT = {
+  eventTypeId: "et-1",
+  startTime: new Date("2026-06-01T15:00:00Z"),
+  bookerName: "Alex",
+  bookerEmail: "alex@example.com",
+  bookerTimezone: "America/Los_Angeles",
+}
+
+describe("createBooking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEventTypeFindUnique.mockResolvedValue(SOLO_EVENT_TYPE)
+    mockHasBookingConflict.mockResolvedValue(false)
+    mockCreateGoogleCalendarEvent.mockResolvedValue({ id: "cal-1", meetingUrl: "https://meet/x" })
+    mockBookingCreate.mockResolvedValue({
+      id: "bk-1",
+      uid: "uid-1",
+      meetingUrl: "https://meet/x",
+      bookerName: "Alex",
+      bookerEmail: "alex@example.com",
+    })
+    mockContactUpsert.mockResolvedValue({})
+    mockSendEmail.mockResolvedValue({})
+    mockBuildBookingPayload.mockResolvedValue({ booking: {}, eventType: {}, host: {} })
+    mockCalendarConnectionFindFirst.mockResolvedValue(null)
+    mockTriggerWebhooks.mockResolvedValue({})
+  })
+
+  describe("error paths", () => {
+    it("returns EVENT_TYPE_NOT_FOUND when event type missing", async () => {
+      mockEventTypeFindUnique.mockResolvedValueOnce(null)
+      const result = await createBooking(VALID_INPUT)
+      expect(result).toEqual({ ok: false, error: "EVENT_TYPE_NOT_FOUND", status: 404 })
+    })
+
+    it("returns CONFLICT when slot is taken", async () => {
+      mockHasBookingConflict.mockResolvedValueOnce(true)
+      const result = await createBooking(VALID_INPUT)
+      expect(result).toEqual({ ok: false, error: "CONFLICT", status: 409 })
+      expect(mockBookingCreate).not.toHaveBeenCalled()
+    })
+
+    it("returns FORBIDDEN when requireOwnerUserId doesn't match", async () => {
+      const result = await createBooking({
+        ...VALID_INPUT,
+        requireOwnerUserId: "someone-else",
+      })
+      expect(result).toEqual({ ok: false, error: "FORBIDDEN", status: 403 })
+      expect(mockBookingCreate).not.toHaveBeenCalled()
+    })
+
+    it("succeeds when requireOwnerUserId matches the event type owner", async () => {
+      const result = await createBooking({
+        ...VALID_INPUT,
+        requireOwnerUserId: "host-1",
+      })
+      expect(result.ok).toBe(true)
+    })
+  })
+
+  describe("happy path", () => {
+    it("creates the booking with derived endTime and meeting link", async () => {
+      const result = await createBooking(VALID_INPUT)
+      expect(result.ok).toBe(true)
+      expect(mockBookingCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            eventTypeId: "et-1",
+            userId: "host-1",
+            startTime: VALID_INPUT.startTime,
+            endTime: new Date("2026-06-01T15:30:00Z"), // +30min from event type
+            meetingUrl: "https://meet/x",
+            meetingId: "cal-1",
+            status: "CONFIRMED",
+          }),
+        })
+      )
+    })
+
+    it("sets status PENDING when event type requires payment", async () => {
+      mockEventTypeFindUnique.mockResolvedValueOnce({ ...SOLO_EVENT_TYPE, requirePayment: true })
+      await createBooking(VALID_INPUT)
+      expect(mockBookingCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: "PENDING" }) })
+      )
+    })
+
+    it("upserts the contact for this booker", async () => {
+      await createBooking(VALID_INPUT)
+      expect(mockContactUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId_email: { userId: "host-1", email: "alex@example.com" } },
+        })
+      )
+    })
+
+    it("triggers booking.created webhook with normalized payload", async () => {
+      await createBooking(VALID_INPUT)
+      expect(mockBuildBookingPayload).toHaveBeenCalledWith("bk-1")
+      expect(mockTriggerWebhooks).toHaveBeenCalledWith(
+        "host-1",
+        "booking.created",
+        expect.any(Object)
+      )
+    })
+
+    it("sends a Zoom-style meeting link when location is ZOOM", async () => {
+      mockEventTypeFindUnique.mockResolvedValueOnce({ ...SOLO_EVENT_TYPE, location: "ZOOM" })
+      mockCreateZoomMeeting.mockResolvedValueOnce({ id: "zm-1", url: "https://zoom/x" })
+      await createBooking(VALID_INPUT)
+      expect(mockCreateGoogleCalendarEvent).not.toHaveBeenCalled()
+      expect(mockBookingCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ meetingUrl: "https://zoom/x", meetingId: "zm-1" }),
+        })
+      )
+    })
+
+    it("emits no meeting URL for IN_PERSON / PHONE", async () => {
+      mockEventTypeFindUnique.mockResolvedValueOnce({ ...SOLO_EVENT_TYPE, location: "IN_PERSON" })
+      await createBooking(VALID_INPUT)
+      expect(mockBookingCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ meetingUrl: undefined, meetingId: undefined }),
+        })
+      )
+    })
+
+    it("creates an Outlook calendar event when one is connected and location isn't GOOGLE_MEET", async () => {
+      mockEventTypeFindUnique.mockResolvedValueOnce({ ...SOLO_EVENT_TYPE, location: "ZOOM" })
+      mockCreateZoomMeeting.mockResolvedValueOnce({ id: "zm-1", url: "https://zoom/x" })
+      mockCalendarConnectionFindFirst.mockResolvedValueOnce({ id: "outlook-conn" })
+
+      await createBooking(VALID_INPUT)
+      expect(mockCreateOutlookCalendarEvent).toHaveBeenCalled()
+    })
+
+    it("does NOT create an Outlook event for GOOGLE_MEET bookings", async () => {
+      await createBooking(VALID_INPUT)
+      expect(mockCreateOutlookCalendarEvent).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/lib/bookings/create.ts
+++ b/src/lib/bookings/create.ts
@@ -1,0 +1,205 @@
+import type { Booking, EventType, User } from "@prisma/client"
+import prisma from "@/lib/prisma"
+import { sendEmail, bookingConfirmationEmail } from "@/lib/email"
+import { createGoogleCalendarEvent } from "@/lib/calendar/google"
+import { createOutlookCalendarEvent } from "@/lib/calendar/outlook"
+import { createZoomMeeting } from "@/lib/video"
+import { triggerWebhooks } from "@/lib/webhooks"
+import { buildBookingPayload } from "@/lib/webhooks/booking-payload"
+import { hasBookingConflict } from "./conflict-check"
+import { format } from "date-fns"
+import { toZonedTime } from "date-fns-tz"
+
+export interface CreateBookingInput {
+  eventTypeId: string
+  startTime: Date | string
+  bookerName: string
+  bookerEmail: string
+  bookerTimezone: string
+  bookerPhone?: string | null
+  answers?: unknown
+  // If set, the helper enforces eventType.userId === requireOwnerUserId.
+  // Used by the v1 API so an API-key holder can only book their own
+  // event types. Public booking-page POST omits this.
+  requireOwnerUserId?: string
+}
+
+export type CreateBookingResult =
+  | { ok: true; booking: Booking }
+  | {
+      ok: false
+      error: "EVENT_TYPE_NOT_FOUND" | "FORBIDDEN" | "CONFLICT"
+      status: number
+    }
+
+// Single source of truth for booking creation. Used by the public booking-page
+// POST and the authenticated /api/v1/bookings POST. Handles conflict checking
+// (across all hosts for collective event types), calendar event + meeting link
+// generation, contact upsert, confirmation emails, and webhook fanout.
+export async function createBooking(input: CreateBookingInput): Promise<CreateBookingResult> {
+  const eventType = await prisma.eventType.findUnique({
+    where: { id: input.eventTypeId },
+    include: { user: true },
+  })
+  if (!eventType) {
+    return { ok: false, error: "EVENT_TYPE_NOT_FOUND", status: 404 }
+  }
+
+  if (input.requireOwnerUserId && eventType.userId !== input.requireOwnerUserId) {
+    return { ok: false, error: "FORBIDDEN", status: 403 }
+  }
+
+  const start = typeof input.startTime === "string" ? new Date(input.startTime) : input.startTime
+  const end = new Date(start.getTime() + eventType.duration * 60000)
+
+  if (await hasBookingConflict({ eventType, start, end })) {
+    return { ok: false, error: "CONFLICT", status: 409 }
+  }
+
+  const { meetingUrl, meetingId } = await generateMeeting(eventType, input, start, end)
+
+  const booking = await prisma.booking.create({
+    data: {
+      eventTypeId: eventType.id,
+      userId: eventType.userId,
+      title: eventType.title,
+      startTime: start,
+      endTime: end,
+      bookerName: input.bookerName,
+      bookerEmail: input.bookerEmail,
+      bookerTimezone: input.bookerTimezone,
+      bookerPhone: input.bookerPhone ?? null,
+      location: eventType.location,
+      meetingUrl,
+      meetingId,
+      answers: (input.answers ?? null) as any,
+      status: eventType.requirePayment ? "PENDING" : "CONFIRMED",
+    },
+  })
+
+  await prisma.contact.upsert({
+    where: { userId_email: { userId: eventType.userId, email: input.bookerEmail } },
+    update: { name: input.bookerName, phone: input.bookerPhone ?? null },
+    create: {
+      userId: eventType.userId,
+      name: input.bookerName,
+      email: input.bookerEmail,
+      phone: input.bookerPhone ?? null,
+      source: "booking",
+    },
+  })
+
+  await sendConfirmationEmails(eventType, booking, input.bookerTimezone, start)
+  await fanoutWebhooks(eventType.userId, booking.id)
+  await maybeCreateOutlookEvent(eventType, booking, start, end, input.bookerEmail)
+
+  return { ok: true, booking }
+}
+
+// ── helpers, kept private to avoid widening the module surface ──
+
+async function generateMeeting(
+  eventType: EventType & { user: User },
+  input: CreateBookingInput,
+  start: Date,
+  end: Date
+): Promise<{ meetingUrl?: string; meetingId?: string }> {
+  if (eventType.location === "GOOGLE_MEET") {
+    const calEvent = await createGoogleCalendarEvent(eventType.userId, {
+      summary: `${eventType.title} - ${input.bookerName}`,
+      description: `Booked via TinyCal`,
+      startTime: start,
+      endTime: end,
+      attendees: [{ email: input.bookerEmail }],
+      conferenceData: true,
+    })
+    return { meetingUrl: calEvent?.meetingUrl ?? undefined, meetingId: calEvent?.id ?? undefined }
+  }
+  if (eventType.location === "ZOOM") {
+    const zoom = await createZoomMeeting({
+      topic: `${eventType.title} - ${input.bookerName}`,
+      startTime: start,
+      duration: eventType.duration,
+    })
+    return { meetingUrl: zoom?.url, meetingId: zoom?.id }
+  }
+  return {}
+}
+
+async function sendConfirmationEmails(
+  eventType: EventType & { user: User },
+  booking: Booking,
+  bookerTimezone: string,
+  start: Date
+) {
+  const zonedStart = toZonedTime(start, bookerTimezone)
+  const dateTimeStr = format(zonedStart, "EEEE, MMMM d, yyyy 'at' h:mm a")
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL!
+
+  try {
+    await sendEmail({
+      to: booking.bookerEmail,
+      subject: `Confirmed: ${eventType.title} with ${eventType.user.name}`,
+      html: bookingConfirmationEmail({
+        bookerName: booking.bookerName,
+        hostName: eventType.user.name || "Host",
+        eventTitle: eventType.title,
+        dateTime: dateTimeStr,
+        timezone: bookerTimezone,
+        location: eventType.location,
+        meetingUrl: booking.meetingUrl ?? undefined,
+        rescheduleUrl: `${appUrl}/reschedule/${booking.uid}`,
+        cancelUrl: `${appUrl}/cancel/${booking.uid}`,
+      }),
+    })
+  } catch (e) {
+    console.error("Email send failed:", e)
+  }
+
+  if (eventType.user.email) {
+    try {
+      await sendEmail({
+        to: eventType.user.email,
+        subject: `New booking: ${eventType.title} with ${booking.bookerName}`,
+        html: bookingConfirmationEmail({
+          bookerName: eventType.user.name || "Host",
+          hostName: booking.bookerName,
+          eventTitle: eventType.title,
+          dateTime: dateTimeStr,
+          timezone: bookerTimezone,
+          location: eventType.location,
+          meetingUrl: booking.meetingUrl ?? undefined,
+          rescheduleUrl: `${appUrl}/reschedule/${booking.uid}`,
+          cancelUrl: `${appUrl}/cancel/${booking.uid}`,
+        }),
+      })
+    } catch (e) {
+      console.error("Host email send failed:", e)
+    }
+  }
+}
+
+async function fanoutWebhooks(userId: string, bookingId: string) {
+  const payload = await buildBookingPayload(bookingId)
+  if (payload) await triggerWebhooks(userId, "booking.created", payload)
+}
+
+async function maybeCreateOutlookEvent(
+  eventType: EventType & { user: User },
+  booking: Booking,
+  start: Date,
+  end: Date,
+  bookerEmail: string
+) {
+  if (eventType.location === "GOOGLE_MEET") return
+  const outlookConn = await prisma.calendarConnection.findFirst({
+    where: { userId: eventType.userId, provider: "OUTLOOK" },
+  })
+  if (!outlookConn) return
+  await createOutlookCalendarEvent(eventType.userId, {
+    summary: `${eventType.title} - ${booking.bookerName}`,
+    startTime: start,
+    endTime: end,
+    attendees: [{ email: bookerEmail }],
+  })
+}


### PR DESCRIPTION
## Summary
- Extracts the booking-creation logic from `/api/bookings` into `src/lib/bookings/create.ts` — single source of truth for: conflict check, calendar event + meeting link generation, contact upsert, confirmation emails, webhook fanout, Outlook mirror
- New `POST /api/v1/bookings` (authenticated) calls the same lib, with zod body validation and an ownership check (the event type must belong to the API key's owner — `403` otherwise)
- Public `POST /api/bookings` keeps its existing behavior, just delegated

## Why
Per #36: Mira (the WhatsApp concierge from #33) needs a server-to-server booking endpoint. Hand-rolling a parallel implementation would drift from the public route — extracting a shared lib avoids that and inherits the collective-conflict fix from #34 / PR #39 for free.

## API shape
```http
POST /api/v1/bookings
Authorization: Bearer tc_live_<prefix>_<secret>
Content-Type: application/json

{
  "eventTypeId":     "ckxyz789",
  "startTime":       "2026-06-01T15:00:00Z",
  "bookerName":      "Alex",
  "bookerEmail":     "alex@example.com",
  "bookerTimezone":  "America/Los_Angeles",
  "bookerPhone":     "+15551234567",
  "answers":         { "q_1": "answer" }
}
```

Returns `201 { "data": <booking-with-meetingUrl> }`.

Errors: `400` (invalid body), `401` (auth), `403` (event type not owned by API key holder), `404` (event type missing), `409` (slot taken), `429` (rate limited).

## Test plan
- [x] `npx vitest run src/lib/bookings src/__tests__/api/v1-bookings` — 31/31 pass
- [x] Full suite — 152/152 pass
- [x] `npx tsc --noEmit` — no new errors
- [ ] `curl -H "Authorization: Bearer tc_live_..." -d '{...}' .../api/v1/bookings` creates a booking and returns the meeting URL
- [ ] Same call against an event type owned by a different user returns 403
- [ ] Same call with malformed body returns 400 with details
- [ ] Public `/api/bookings` still works from the booking page (regression check)

Closes #36
Part of #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)