### PR TITLE
chore(deploy): run prisma migrate deploy as part of vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
One-line change to the build script: chain \`prisma migrate deploy\` between \`prisma generate\` and \`next build\`.

## Why
Discovered while trying to mint an API key for prod smoke-testing of #36/#37: the migration from #40 (\`20260509000000_add_api_keys\`) was committed and shipped to prod, but no one had applied it to the database. The deploy succeeded, but the new \`/api/v1/*\` routes that depend on the \`ApiKey\` table would have hit \`P2021: The table public.ApiKey does not exist\` on the first real auth attempt.

Root cause: build was \`prisma generate && next build\`. Generate updates types, but doesn't touch the DB.

## Caveat / risk
Every Vercel build (preview included) will now run \`migrate deploy\` against whatever \`DATABASE_URL\` is in scope. \`migrate deploy\` is idempotent (forward-only, no-op when nothing's pending) so re-runs are safe. For TinyCal as it's deployed today (single prod DB), this is fine. If preview deployments ever get pointed at a separate branch DB, that DB will receive the same migrations.

If two deployments race to apply the same migration concurrently, Prisma uses an advisory lock to serialize them — the second deploy waits.

## Test plan
- [ ] Merge → next deploy logs show \`Applying migration "20260509000000_add_api_keys"\` (or "no migrations to apply" if I've already applied it manually for the smoke test)
- [ ] Subsequent deploys log "no migrations to apply"
- [ ] \`/api/v1/event-types\` no longer 500s on auth attempts that touch the ApiKey table

🤖 Generated with [Claude Code](https://claude.com/claude-code)