### PR TITLE
fix(middleware): allow /api/v1/* through Auth.js so Bearer auth works

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,15 @@
 import { auth } from '@/auth'
 import { NextResponse } from 'next/server'
 
+// Routes that handle their own authentication (Bearer / webhook signature /
+// public access). Auth.js middleware must not gate them with a session check —
+// otherwise Bearer-token clients get 401 before the route handler runs.
 const publicRoutes = [
   '/', '/login',
   '/api/webhooks', '/api/availability', '/api/bookings',
   '/api/slots', '/api/stripe/webhook', '/api/auth',
   '/api/meeting-links',
+  '/api/v1',  // REST API — auths via Bearer api key in route handler
 ]
 
 function isPublicRoute(pathname: string): boolean {


### PR DESCRIPTION
## Summary
Add \`/api/v1\` to \`publicRoutes\` in \`src/middleware.ts\` so Bearer-token authenticated requests reach the route handler instead of being short-circuited by Auth.js with a 401.

## Root cause
The Auth.js middleware in \`src/middleware.ts:24-38\` gates every \`/api/*\` route on a session cookie unless the path is whitelisted in \`publicRoutes\`. The \`/api/v1/*\` routes use Bearer-token auth via \`authenticateApiKey()\` (#40), not session auth — but \`/api/v1\` was never added to the whitelist, so the middleware sees no session and returns 401 before \`authenticateApiKey()\` runs. **The token was never even read.**

This made the entire REST API surface effectively non-functional in production, including the legacy \`User.id\`-as-Bearer path that predates #40.

## How discovered
Smoke-testing PR #43/#44 against prod with a freshly-minted \`tc_live_...\` key:

\`\`\`
$ curl -H "Authorization: Bearer tc_live_..." https://tinycal.zenithstudio.app/api/v1/event-types
HTTP/2 401 {"error":"Unauthorized"}
\`\`\`

Confirmed it wasn't a wrong-DB or stale-deploy issue by:
1. Verifying silent-pond is the prod DB
2. Verifying the User row + ApiKey row both exist in silent-pond
3. Verifying the legacy \`User.id\` Bearer also returns 401 (proving the new auth code wasn't even being reached)

That last point pointed at middleware.

## Test plan
- [x] All 156 unit tests still pass (no test changes — middleware tests are awkward to set up without Auth.js fixtures)
- [ ] After merge + deploy: \`curl -H "Authorization: Bearer <tc_live_...>" .../api/v1/event-types\` returns 200 with \`{ data: [...] }\` and \`X-RateLimit-*\` headers
- [ ] Same with legacy \`User.id\` Bearer returns 200 with the \`Warning: 299 - "tc-legacy-api-key"\` header
- [ ] Wrong key returns 401 (now from \`authenticateApiKey\`, not middleware)
- [ ] Browser dashboard pages still require login (regression check — middleware should still redirect unauth'd users for non-API non-public routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)