### PR TITLE
feat: co-host picker UI for collective scheduling (#42)

### DIFF
--- a/src/__tests__/api/event-types-id.test.ts
+++ b/src/__tests__/api/event-types-id.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockEventTypeFindFirst = vi.fn()
+const mockEventTypeFindUnique = vi.fn()
+const mockEventTypeUpdate = vi.fn()
+const mockEventTypeDelete = vi.fn()
+const mockUserFindMany = vi.fn()
+const mockUserCount = vi.fn()
+const mockGetAuthenticatedUser = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    eventType: {
+      findFirst: (...args: any[]) => mockEventTypeFindFirst(...args),
+      findUnique: (...args: any[]) => mockEventTypeFindUnique(...args),
+      update: (...args: any[]) => mockEventTypeUpdate(...args),
+      delete: (...args: any[]) => mockEventTypeDelete(...args),
+    },
+    user: {
+      findMany: (...args: any[]) => mockUserFindMany(...args),
+      count: (...args: any[]) => mockUserCount(...args),
+    },
+  },
+}))
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: (...args: any[]) => mockGetAuthenticatedUser(...args),
+}))
+
+import { GET, PATCH, DELETE } from "@/app/api/event-types/[id]/route"
+
+const OWNER = { id: "owner-1" } as any
+const OTHER = { id: "other-1" } as any
+
+const SOLO_ET = {
+  id: "et-1",
+  userId: "owner-1",
+  isCollective: false,
+  collectiveMembers: [] as string[],
+  questions: [],
+}
+
+const COLLECTIVE_ET = {
+  id: "et-1",
+  userId: "owner-1",
+  isCollective: true,
+  collectiveMembers: ["alex-id", "morgan-id"],
+  questions: [],
+}
+
+describe("GET /api/event-types/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+  })
+
+  it("returns the event type with empty collectiveHosts when not collective", async () => {
+    mockEventTypeFindFirst.mockResolvedValueOnce(SOLO_ET)
+    const res = await GET(new Request("http://x"), { params: { id: "et-1" } })
+    const body = await res.json()
+    expect(body.collectiveHosts).toEqual([])
+    expect(mockUserFindMany).not.toHaveBeenCalled()
+  })
+
+  it("resolves collectiveMembers IDs to host summaries", async () => {
+    mockEventTypeFindFirst.mockResolvedValueOnce(COLLECTIVE_ET)
+    mockUserFindMany.mockResolvedValueOnce([
+      { id: "alex-id", name: "Alex", email: "alex@example.com" },
+      { id: "morgan-id", name: "Morgan", email: "morgan@example.com" },
+    ])
+
+    const res = await GET(new Request("http://x"), { params: { id: "et-1" } })
+    const body = await res.json()
+    expect(body.collectiveHosts).toHaveLength(2)
+    expect(body.collectiveHosts[0]).toEqual({
+      id: "alex-id", name: "Alex", email: "alex@example.com",
+    })
+  })
+
+  it("returns 404 when event type not owned by requester", async () => {
+    mockEventTypeFindFirst.mockResolvedValueOnce(null)
+    const res = await GET(new Request("http://x"), { params: { id: "et-1" } })
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("PATCH /api/event-types/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+    mockEventTypeUpdate.mockResolvedValue({ id: "et-1" })
+  })
+
+  it("blocks PATCH on someone else's event type with 403", async () => {
+    mockEventTypeFindUnique.mockResolvedValueOnce({ userId: OTHER.id })
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: "{}" }),
+      { params: { id: "et-1" } }
+    )
+    expect(res.status).toBe(403)
+    expect(mockEventTypeUpdate).not.toHaveBeenCalled()
+  })
+
+  it("returns 404 when event type doesn't exist at all", async () => {
+    mockEventTypeFindUnique.mockResolvedValueOnce(null)
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: "{}" }),
+      { params: { id: "et-1" } }
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("rejects collectiveMembers payload that contains unknown user IDs (400)", async () => {
+    mockEventTypeFindUnique.mockResolvedValueOnce({ userId: OWNER.id })
+    mockUserCount.mockResolvedValueOnce(1) // only 1 of 2 IDs found
+
+    const res = await PATCH(
+      new Request("http://x", {
+        method: "PATCH",
+        body: JSON.stringify({ collectiveMembers: ["real-id", "fake-id"] }),
+      }),
+      { params: { id: "et-1" } }
+    )
+    expect(res.status).toBe(400)
+    expect(mockEventTypeUpdate).not.toHaveBeenCalled()
+  })
+
+  it("happy path: PATCH succeeds when owner + valid payload", async () => {
+    mockEventTypeFindUnique.mockResolvedValueOnce({ userId: OWNER.id })
+    mockUserCount.mockResolvedValueOnce(2)
+
+    const res = await PATCH(
+      new Request("http://x", {
+        method: "PATCH",
+        body: JSON.stringify({
+          title: "Updated",
+          collectiveMembers: ["alex-id", "morgan-id"],
+        }),
+      }),
+      { params: { id: "et-1" } }
+    )
+    expect(res.status).toBe(200)
+    expect(mockEventTypeUpdate).toHaveBeenCalled()
+  })
+
+  it("skips the user-existence check when collectiveMembers is empty/missing", async () => {
+    mockEventTypeFindUnique.mockResolvedValueOnce({ userId: OWNER.id })
+    await PATCH(
+      new Request("http://x", { method: "PATCH", body: JSON.stringify({ title: "x" }) }),
+      { params: { id: "et-1" } }
+    )
+    expect(mockUserCount).not.toHaveBeenCalled()
+  })
+})
+
+describe("DELETE /api/event-types/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+  })
+
+  it("blocks DELETE on someone else's event type with 403", async () => {
+    mockEventTypeFindUnique.mockResolvedValueOnce({ userId: OTHER.id })
+    const res = await DELETE(new Request("http://x"), { params: { id: "et-1" } })
+    expect(res.status).toBe(403)
+    expect(mockEventTypeDelete).not.toHaveBeenCalled()
+  })
+
+  it("happy path: DELETE succeeds for owner", async () => {
+    mockEventTypeFindUnique.mockResolvedValueOnce({ userId: OWNER.id })
+    mockEventTypeDelete.mockResolvedValueOnce({})
+    const res = await DELETE(new Request("http://x"), { params: { id: "et-1" } })
+    expect(res.status).toBe(200)
+    expect(mockEventTypeDelete).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/api/users-lookup.test.ts
+++ b/src/__tests__/api/users-lookup.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockUserFindUnique = vi.fn()
+const mockGetAuthenticatedUser = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: { findUnique: (...args: any[]) => mockUserFindUnique(...args) },
+  },
+}))
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: (...args: any[]) => mockGetAuthenticatedUser(...args),
+}))
+
+import { GET } from "@/app/api/users/lookup/route"
+
+const REQUESTER = { id: "u1", email: "me@x.com" } as any
+const TARGET = { id: "u2", name: "Alex", email: "alex@example.com" }
+
+describe("GET /api/users/lookup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(REQUESTER)
+  })
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(null)
+    const res = await GET(new Request("http://x/api/users/lookup?email=alex@example.com"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 400 when email param is missing", async () => {
+    const res = await GET(new Request("http://x/api/users/lookup"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 404 when no user matches", async () => {
+    mockUserFindUnique.mockResolvedValueOnce(null)
+    const res = await GET(new Request("http://x/api/users/lookup?email=nobody@x.com"))
+    expect(res.status).toBe(404)
+  })
+
+  it("returns id/name/email for a matching user", async () => {
+    mockUserFindUnique.mockResolvedValueOnce(TARGET)
+    const res = await GET(new Request("http://x/api/users/lookup?email=alex@example.com"))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ data: TARGET })
+  })
+
+  it("normalizes the email to lowercase + trim before lookup", async () => {
+    mockUserFindUnique.mockResolvedValueOnce(TARGET)
+    await GET(new Request("http://x/api/users/lookup?email=%20Alex%40Example.com%20"))
+    expect(mockUserFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { email: "alex@example.com" } })
+    )
+  })
+
+  it("only selects safe fields (no token/secrets)", async () => {
+    mockUserFindUnique.mockResolvedValueOnce(TARGET)
+    await GET(new Request("http://x/api/users/lookup?email=alex@example.com"))
+    expect(mockUserFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: { id: true, name: true, email: true },
+      })
+    )
+  })
+})

--- a/src/app/api/event-types/[id]/route.ts
+++ b/src/app/api/event-types/[id]/route.ts
@@ -11,14 +11,53 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     include: { questions: { orderBy: { order: "asc" } } },
   })
   if (!eventType) return NextResponse.json({ error: "Not found" }, { status: 404 })
-  return NextResponse.json(eventType)
+
+  // Resolve collectiveMembers (User.id[]) to host summaries so the editor
+  // can render names instead of raw IDs. Skipped for non-collective event
+  // types to avoid a wasted query.
+  let collectiveHosts: { id: string; name: string | null; email: string | null }[] = []
+  if (eventType.isCollective && eventType.collectiveMembers.length > 0) {
+    collectiveHosts = await prisma.user.findMany({
+      where: { id: { in: eventType.collectiveMembers } },
+      select: { id: true, name: true, email: true },
+    })
+  }
+
+  return NextResponse.json({ ...eventType, collectiveHosts })
 }
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   const user = await getAuthenticatedUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
+  // Ownership check — without this, any authed user could mutate any event
+  // type by guessing the cuid. Pre-existing gap caught while adding the
+  // co-host picker.
+  const existing = await prisma.eventType.findUnique({
+    where: { id: params.id },
+    select: { userId: true },
+  })
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  if (existing.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
   const body = await req.json()
+
+  // If collectiveMembers were sent, reject any IDs that don't resolve to a
+  // real user — guards against typos or stale references in the payload.
+  if (Array.isArray(body.collectiveMembers) && body.collectiveMembers.length > 0) {
+    const found = await prisma.user.count({
+      where: { id: { in: body.collectiveMembers } },
+    })
+    if (found !== body.collectiveMembers.length) {
+      return NextResponse.json(
+        { error: "One or more collectiveMembers IDs don't resolve to a TinyCal user" },
+        { status: 400 }
+      )
+    }
+  }
+
   const eventType = await prisma.eventType.update({
     where: { id: params.id },
     data: {
@@ -47,6 +86,16 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   const user = await getAuthenticatedUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  // Same ownership check as PATCH.
+  const existing = await prisma.eventType.findUnique({
+    where: { id: params.id },
+    select: { userId: true },
+  })
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  if (existing.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
 
   await prisma.eventType.delete({ where: { id: params.id } })
   return NextResponse.json({ success: true })

--- a/src/app/api/users/lookup/route.ts
+++ b/src/app/api/users/lookup/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+// Resolves an email address to a public user summary (id, name, email).
+// Used by the event-type editor to pick a co-host for collective scheduling
+// (#42). Session-auth required so we don't expose a user-existence oracle to
+// anonymous callers. Even authed users only get back name/email — no other
+// account fields.
+export async function GET(req: Request) {
+  const requester = await getAuthenticatedUser()
+  if (!requester) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const email = new URL(req.url).searchParams.get("email")?.trim().toLowerCase()
+  if (!email) {
+    return NextResponse.json({ error: "email query parameter required" }, { status: 400 })
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, name: true, email: true },
+  })
+
+  if (!user) {
+    return NextResponse.json(
+      { error: "No TinyCal user found for that email — they need to sign up + connect a calendar first" },
+      { status: 404 }
+    )
+  }
+
+  return NextResponse.json({ data: user })
+}

--- a/src/app/dashboard/event-types/[id]/page.tsx
+++ b/src/app/dashboard/event-types/[id]/page.tsx
@@ -2,14 +2,24 @@
 
 import { useEffect, useState } from "react"
 import { useRouter, useParams } from "next/navigation"
-import { ArrowLeft, Save } from "lucide-react"
+import { ArrowLeft, Save, X, AlertCircle } from "lucide-react"
 import Link from "next/link"
+
+interface CoHost {
+  id: string
+  name: string | null
+  email: string | null
+}
 
 export default function EditEventTypePage() {
   const params = useParams()
   const router = useRouter()
   const [et, setEt] = useState<any>(null)
   const [saving, setSaving] = useState(false)
+
+  const [coHostEmail, setCoHostEmail] = useState("")
+  const [coHostError, setCoHostError] = useState<string | null>(null)
+  const [coHostAdding, setCoHostAdding] = useState(false)
 
   useEffect(() => {
     fetch(`/api/event-types/${params.id}`).then(r => r.json()).then(setEt)
@@ -26,7 +36,52 @@ export default function EditEventTypePage() {
     router.push("/dashboard/event-types")
   }
 
+  async function addCoHost() {
+    const email = coHostEmail.trim().toLowerCase()
+    if (!email) return
+    setCoHostError(null)
+
+    if (email === et.user?.email) {
+      setCoHostError("That's the event-type owner — already a host by default")
+      return
+    }
+    if ((et.collectiveHosts ?? []).some((h: CoHost) => h.email === email)) {
+      setCoHostError("Already added")
+      return
+    }
+
+    setCoHostAdding(true)
+    try {
+      const res = await fetch(`/api/users/lookup?email=${encodeURIComponent(email)}`)
+      const body = await res.json()
+      if (!res.ok) {
+        setCoHostError(body.error || "Lookup failed")
+        return
+      }
+      const newHost: CoHost = body.data
+      setEt({
+        ...et,
+        collectiveMembers: [...(et.collectiveMembers ?? []), newHost.id],
+        collectiveHosts: [...(et.collectiveHosts ?? []), newHost],
+      })
+      setCoHostEmail("")
+    } finally {
+      setCoHostAdding(false)
+    }
+  }
+
+  function removeCoHost(id: string) {
+    setEt({
+      ...et,
+      collectiveMembers: (et.collectiveMembers ?? []).filter((x: string) => x !== id),
+      collectiveHosts: (et.collectiveHosts ?? []).filter((h: CoHost) => h.id !== id),
+    })
+  }
+
   if (!et) return <div className="animate-pulse">Loading...</div>
+
+  const showsEmptyCollectiveWarning =
+    et.isCollective && (et.collectiveMembers ?? []).length === 0
 
   return (
     <div>
@@ -142,6 +197,65 @@ export default function EditEventTypePage() {
             className="rounded" id="isCollective" />
           <label htmlFor="isCollective" className="text-sm">Collective scheduling (find time for multiple hosts)</label>
         </div>
+
+        {et.isCollective && (
+          <div className="border rounded-lg p-4 space-y-3 bg-gray-50">
+            <div>
+              <h4 className="font-medium text-sm">Co-hosts</h4>
+              <p className="text-xs text-gray-600 mt-1">
+                Add other TinyCal users whose availability and connected calendars must also be free for a slot to be bookable.
+              </p>
+            </div>
+
+            {(et.collectiveHosts ?? []).length > 0 && (
+              <ul className="space-y-2">
+                {(et.collectiveHosts as CoHost[]).map(h => (
+                  <li key={h.id} className="flex items-center justify-between bg-white border rounded-lg px-3 py-2">
+                    <div>
+                      <div className="text-sm font-medium">{h.name || "(no name)"}</div>
+                      <div className="text-xs text-gray-600">{h.email}</div>
+                    </div>
+                    <button type="button" onClick={() => removeCoHost(h.id)}
+                      aria-label={`Remove ${h.email}`}
+                      className="p-1 hover:bg-gray-100 rounded">
+                      <X className="w-4 h-4 text-gray-600" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {showsEmptyCollectiveWarning && (
+              <div className="flex items-start gap-2 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                <span>
+                  Collective scheduling is on but no co-hosts are added —
+                  bookings will only check your availability.
+                </span>
+              </div>
+            )}
+
+            <form onSubmit={e => { e.preventDefault(); addCoHost() }} className="flex gap-2">
+              <input
+                type="email"
+                value={coHostEmail}
+                onChange={e => { setCoHostEmail(e.target.value); setCoHostError(null) }}
+                placeholder="co-host@example.com"
+                className="flex-1 border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+              />
+              <button type="submit" disabled={coHostAdding || !coHostEmail.trim()}
+                className="bg-gray-900 text-white text-sm px-4 py-2 rounded-lg hover:bg-gray-800 disabled:opacity-50">
+                {coHostAdding ? "Adding..." : "Add"}
+              </button>
+            </form>
+
+            {coHostError && (
+              <div className="text-xs text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2">
+                {coHostError}
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="flex items-center gap-3">
           <input type="checkbox" checked={et.active} onChange={e => setEt({ ...et, active: e.target.checked })}


### PR DESCRIPTION
## Summary
- New Co-hosts section in the event-type editor, revealed when **Collective scheduling** is checked
- Add by email → resolves to a TinyCal user via new \`GET /api/users/lookup\` endpoint, or shows an inline error if no match
- Removable chips for each existing co-host (shows name + email, not raw user IDs)
- Inline warning when collective is on but no co-hosts are added

## Why
Per #42 (discovered while answering the "do I add Alex's calendar to mine?" question): collective scheduling could be toggled in the dashboard, but the only way to actually populate \`collectiveMembers\` was a direct API/DB poke. This blocked the Sze + Alex flow #33 needs.

Slot lookup + booking-side conflict checks already worked correctly once \`collectiveMembers\` was populated — this PR just makes the configuration step usable from the dashboard.

## Backend changes
- **New** \`GET /api/users/lookup?email=…\` (session-auth) → \`{ data: { id, name, email } }\` or 404. Auth-gated so it's not an existence oracle for anonymous callers; only safe fields are returned.
- **Enhanced** \`GET /api/event-types/[id]\` to also return \`collectiveHosts: [{ id, name, email }]\` so the editor can render names instead of raw IDs. No N+1 — single \`findMany\` against the IDs.
- **Tightened** \`PATCH /api/event-types/[id]\` to reject \`collectiveMembers\` IDs that don't resolve to real users.

## Bonus security fix (pre-existing)
\`PATCH\` and \`DELETE /api/event-types/[id]\` previously had no ownership check — any authenticated user could mutate or delete *anyone's* event type by guessing the cuid. Both now look up the row first and 403 if it isn't owned by the requester. (\`GET\` was already correct.)

## Test plan
- [x] \`npx vitest run src/__tests__/api/users-lookup src/__tests__/api/event-types-id\` — 16/16 pass
- [x] Full unit suite — 172/172 pass
- [x] \`npx tsc --noEmit\` — no new errors
- [ ] **Manual**: enable collective on an event type → add a real teammate by email → save → reopen and confirm they're listed → remove → save → confirm gone
- [ ] **Manual**: add a non-existent email → see "No TinyCal user found…" error inline, not added to list
- [ ] **Manual**: try adding the event-type owner's own email → see "already a host by default" inline error
- [ ] **Manual**: with collective on and zero co-hosts → see the amber warning banner
- [ ] **Manual security check**: as user A, try \`curl -X PATCH .../api/event-types/<userB-event-type-id>\` → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)