### PR TITLE
feat(dashboard): API keys page (list / create / revoke)

### DIFF
--- a/src/__tests__/api/api-keys-routes.test.ts
+++ b/src/__tests__/api/api-keys-routes.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockApiKeyFindMany = vi.fn()
+const mockApiKeyFindUnique = vi.fn()
+const mockApiKeyCreate = vi.fn()
+const mockApiKeyUpdate = vi.fn()
+const mockGetAuthenticatedUser = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    apiKey: {
+      findMany: (...args: any[]) => mockApiKeyFindMany(...args),
+      findUnique: (...args: any[]) => mockApiKeyFindUnique(...args),
+      create: (...args: any[]) => mockApiKeyCreate(...args),
+      update: (...args: any[]) => mockApiKeyUpdate(...args),
+    },
+  },
+}))
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: (...args: any[]) => mockGetAuthenticatedUser(...args),
+}))
+
+import { GET, POST } from "@/app/api/api-keys/route"
+import { POST as REVOKE } from "@/app/api/api-keys/[id]/revoke/route"
+
+const OWNER = { id: "owner-1" } as any
+const OTHER = { id: "other-1" } as any
+
+describe("GET /api/api-keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+  })
+
+  it("returns 401 unauthenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(null)
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it("scopes the list to the requester's user id", async () => {
+    mockApiKeyFindMany.mockResolvedValueOnce([])
+    await GET()
+    expect(mockApiKeyFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: OWNER.id } })
+    )
+  })
+
+  it("does not expose hashedSecret in the select", async () => {
+    mockApiKeyFindMany.mockResolvedValueOnce([])
+    await GET()
+    const select = mockApiKeyFindMany.mock.calls[0][0].select
+    expect(select.hashedSecret).toBeUndefined()
+  })
+})
+
+describe("POST /api/api-keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+    mockApiKeyCreate.mockResolvedValue({
+      id: "ak-1", name: "test", prefix: "abcd1234", createdAt: new Date(),
+    })
+  })
+
+  function makeReq(body: unknown): Request {
+    return new Request("http://x/api/api-keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    })
+  }
+
+  it("returns 401 unauthenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(null)
+    const res = await POST(makeReq({ name: "test" }))
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects malformed JSON", async () => {
+    const res = await POST(makeReq("{broken"))
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects missing name", async () => {
+    const res = await POST(makeReq({}))
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects empty/whitespace name", async () => {
+    const res = await POST(makeReq({ name: "   " }))
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects names over 80 chars", async () => {
+    const res = await POST(makeReq({ name: "a".repeat(81) }))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 201 with fullKey on success", async () => {
+    const res = await POST(makeReq({ name: "Mira concierge" }))
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data.fullKey).toMatch(/^tc_live_/)
+    expect(body.data.name).toBe("test")
+    expect(body.data.prefix).toBeTruthy()
+  })
+
+  it("persists prefix + hashedSecret with the requester as owner", async () => {
+    await POST(makeReq({ name: "Mira concierge" }))
+    const data = mockApiKeyCreate.mock.calls[0][0].data
+    expect(data.userId).toBe(OWNER.id)
+    expect(data.prefix).toMatch(/^[0-9a-f]{8}$/)
+    expect(data.hashedSecret).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+describe("POST /api/api-keys/[id]/revoke", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+  })
+
+  it("returns 401 unauthenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(null)
+    const res = await REVOKE(new Request("http://x"), { params: { id: "ak-1" } })
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 404 for unknown key id", async () => {
+    mockApiKeyFindUnique.mockResolvedValueOnce(null)
+    const res = await REVOKE(new Request("http://x"), { params: { id: "ak-1" } })
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 403 when revoking someone else's key", async () => {
+    mockApiKeyFindUnique.mockResolvedValueOnce({ userId: OTHER.id, revokedAt: null })
+    const res = await REVOKE(new Request("http://x"), { params: { id: "ak-1" } })
+    expect(res.status).toBe(403)
+    expect(mockApiKeyUpdate).not.toHaveBeenCalled()
+  })
+
+  it("sets revokedAt for owner's active key", async () => {
+    mockApiKeyFindUnique.mockResolvedValueOnce({ userId: OWNER.id, revokedAt: null })
+    mockApiKeyUpdate.mockResolvedValueOnce({})
+    const res = await REVOKE(new Request("http://x"), { params: { id: "ak-1" } })
+    expect(res.status).toBe(200)
+    expect(mockApiKeyUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "ak-1" },
+        data: expect.objectContaining({ revokedAt: expect.any(Date) }),
+      })
+    )
+  })
+
+  it("is idempotent — re-revoking is a no-op (200, no update call)", async () => {
+    mockApiKeyFindUnique.mockResolvedValueOnce({
+      userId: OWNER.id, revokedAt: new Date("2026-01-01"),
+    })
+    const res = await REVOKE(new Request("http://x"), { params: { id: "ak-1" } })
+    expect(res.status).toBe(200)
+    expect(mockApiKeyUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/api-keys/[id]/revoke/route.ts
+++ b/src/app/api/api-keys/[id]/revoke/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+// Soft-revoke an API key. Idempotent: re-revoking is a no-op. The row stays
+// so historical lastUsedAt and per-key usage counters remain queryable.
+export async function POST(_req: Request, { params }: { params: { id: string } }) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const apiKey = await prisma.apiKey.findUnique({
+    where: { id: params.id },
+    select: { userId: true, revokedAt: true },
+  })
+  if (!apiKey) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  if (apiKey.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  if (!apiKey.revokedAt) {
+    await prisma.apiKey.update({
+      where: { id: params.id },
+      data: { revokedAt: new Date() },
+    })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+import { generateApiKey } from "@/lib/api-keys/generate"
+
+// List the current user's API keys (no secrets returned).
+export async function GET() {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const keys = await prisma.apiKey.findMany({
+    where: { userId: user.id },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      name: true,
+      prefix: true,
+      lastUsedAt: true,
+      expiresAt: true,
+      revokedAt: true,
+      createdAt: true,
+    },
+  })
+  return NextResponse.json({ data: keys })
+}
+
+// Mint a new API key. The full secret is returned exactly ONCE in this
+// response — never retrievable later, only the prefix + sha256(secret) hash
+// persist.
+export async function POST(req: Request) {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  let body: { name?: string }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const name = body.name?.trim()
+  if (!name) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 })
+  }
+  if (name.length > 80) {
+    return NextResponse.json({ error: "name must be 80 chars or fewer" }, { status: 400 })
+  }
+
+  const { fullKey, prefix, hashedSecret } = generateApiKey()
+
+  const apiKey = await prisma.apiKey.create({
+    data: { userId: user.id, prefix, hashedSecret, name, scopes: [] },
+    select: {
+      id: true, name: true, prefix: true, createdAt: true,
+    },
+  })
+
+  return NextResponse.json(
+    { data: { ...apiKey, fullKey } },
+    { status: 201 }
+  )
+}

--- a/src/app/dashboard/api-keys/page.tsx
+++ b/src/app/dashboard/api-keys/page.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Plus, Copy, Check, AlertTriangle, KeyRound } from "lucide-react"
+
+interface ApiKey {
+  id: string
+  name: string
+  prefix: string
+  lastUsedAt: string | null
+  expiresAt: string | null
+  revokedAt: string | null
+  createdAt: string
+}
+
+interface CreatedKey {
+  id: string
+  name: string
+  prefix: string
+  fullKey: string
+}
+
+function fmtDate(d: string | null): string {
+  if (!d) return "—"
+  return new Date(d).toLocaleDateString(undefined, {
+    year: "numeric", month: "short", day: "numeric",
+  })
+}
+
+export default function ApiKeysPage() {
+  const [keys, setKeys] = useState<ApiKey[] | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [createName, setCreateName] = useState("")
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [justCreated, setJustCreated] = useState<CreatedKey | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  async function load() {
+    const res = await fetch("/api/api-keys")
+    const body = await res.json()
+    setKeys(body.data ?? [])
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    setCreateError(null)
+    setCreating(true)
+    try {
+      const res = await fetch("/api/api-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: createName.trim() }),
+      })
+      const body = await res.json()
+      if (!res.ok) {
+        setCreateError(body.error || "Failed to create key")
+        return
+      }
+      setJustCreated(body.data)
+      setShowCreate(false)
+      setCreateName("")
+      load()
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function handleRevoke(id: string, name: string) {
+    if (!confirm(`Revoke "${name}"? Any client using it will start getting 401 immediately.`)) return
+    const res = await fetch(`/api/api-keys/${id}/revoke`, { method: "POST" })
+    if (res.ok) load()
+  }
+
+  async function copyToClipboard(s: string) {
+    await navigator.clipboard.writeText(s)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">API Keys</h1>
+          <p className="text-sm text-gray-600 mt-1">
+            Bearer tokens for the REST API. See{" "}
+            <a href="https://github.com/zenithventure/tinycal#api-documentation" target="_blank" rel="noreferrer"
+              className="text-blue-600 hover:underline">API docs</a>.
+          </p>
+        </div>
+        <button onClick={() => { setShowCreate(true); setJustCreated(null) }}
+          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 flex items-center gap-2 text-sm">
+          <Plus className="w-4 h-4" /> New API Key
+        </button>
+      </div>
+
+      {justCreated && (
+        <div className="mb-4 border-2 border-amber-300 bg-amber-50 rounded-xl p-4">
+          <div className="flex items-start gap-2 mb-3">
+            <AlertTriangle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+            <div>
+              <div className="font-semibold text-amber-900">Save this key now — it will not be shown again</div>
+              <div className="text-xs text-amber-800 mt-0.5">
+                {justCreated.name} · prefix {justCreated.prefix}
+              </div>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <code className="flex-1 bg-white border border-amber-200 rounded px-3 py-2 text-xs font-mono break-all">
+              {justCreated.fullKey}
+            </code>
+            <button onClick={() => copyToClipboard(justCreated.fullKey)}
+              className="bg-amber-600 hover:bg-amber-700 text-white text-sm px-3 py-2 rounded flex items-center gap-1.5">
+              {copied ? <><Check className="w-4 h-4" /> Copied</> : <><Copy className="w-4 h-4" /> Copy</>}
+            </button>
+          </div>
+          <button onClick={() => setJustCreated(null)}
+            className="text-xs text-amber-800 hover:underline mt-3">
+            I&apos;ve saved it — dismiss
+          </button>
+        </div>
+      )}
+
+      {showCreate && (
+        <form onSubmit={handleCreate} className="bg-white border rounded-xl p-4 mb-4">
+          <label className="block text-sm font-medium mb-1">Name</label>
+          <input type="text" value={createName} onChange={e => setCreateName(e.target.value)}
+            placeholder="e.g. Mira concierge bot"
+            required maxLength={80}
+            className="w-full border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none" />
+          {createError && (
+            <div className="text-xs text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2 mt-2">
+              {createError}
+            </div>
+          )}
+          <div className="flex gap-2 justify-end mt-3">
+            <button type="button" onClick={() => { setShowCreate(false); setCreateError(null) }}
+              className="border px-4 py-2 rounded-lg text-sm">Cancel</button>
+            <button type="submit" disabled={creating || !createName.trim()}
+              className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm disabled:opacity-50">
+              {creating ? "Creating..." : "Create"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      <div className="bg-white border rounded-xl divide-y">
+        {keys === null ? (
+          <div className="p-8 text-center text-gray-400 animate-pulse">Loading...</div>
+        ) : keys.length === 0 ? (
+          <div className="p-8 text-center text-gray-500 flex flex-col items-center gap-2">
+            <KeyRound className="w-8 h-8 text-gray-300" />
+            <div>No API keys yet</div>
+          </div>
+        ) : keys.map(k => (
+          <div key={k.id} className="p-4 flex items-center justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-sm">{k.name}</span>
+                {k.revokedAt && (
+                  <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">Revoked</span>
+                )}
+              </div>
+              <div className="text-xs text-gray-600 mt-1 font-mono">
+                tc_live_{k.prefix}…
+              </div>
+              <div className="text-xs text-gray-500 mt-1">
+                Created {fmtDate(k.createdAt)} · Last used {fmtDate(k.lastUsedAt)}
+              </div>
+            </div>
+            {!k.revokedAt && (
+              <button onClick={() => handleRevoke(k.id, k.name)}
+                className="text-sm text-red-600 hover:bg-red-50 px-3 py-1.5 rounded">
+                Revoke
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { Calendar, Clock, Settings, Webhook, LayoutDashboard, LogOut, Users, Menu, X, LifeBuoy, Link2 } from "lucide-react"
+import { Calendar, Clock, Settings, Webhook, LayoutDashboard, LogOut, Users, Menu, X, LifeBuoy, Link2, KeyRound } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/lib/contexts/auth-context"
 
@@ -15,6 +15,7 @@ const navItems = [
   { href: "/dashboard/availability", label: "Availability", icon: Clock },
   { href: "/dashboard/contacts", label: "Contacts", icon: Users },
   { href: "/dashboard/webhooks", label: "Webhooks", icon: Webhook },
+  { href: "/dashboard/api-keys", label: "API Keys", icon: KeyRound },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
   { href: "/dashboard/support", label: "Support", icon: LifeBuoy },
 ]


### PR DESCRIPTION
## Summary
Self-serve API key management at \`/dashboard/api-keys\`. Replaces the \`scripts/create-api-key.ts\` ops workflow.

- **List** existing keys (name, prefix, lastUsedAt, revoked badge). Hashed secret never leaves the server.
- **Create** modal: name input → mints key → displays full \`tc_live_<prefix>_<secret>\` exactly once with Copy + a clear "save now" warning. Reload of the page won't show it again.
- **Revoke** button per active key (with confirm), idempotent — re-revoke is a no-op.
- Sidebar nav gets a new "API Keys" entry between Webhooks and Settings.

## Backend
- \`GET /api/api-keys\` — list current user's keys, no secrets
- \`POST /api/api-keys\` — mint, returns \`fullKey\` ONCE in the response
- \`POST /api/api-keys/[id]/revoke\` — soft-revoke (idempotent), 403 if not the owner, 404 if missing

## Why
Per the Mira prep flow: step 3 is "mint API key at \`/dashboard/api-keys\`". Until now that page didn't exist; minting required SSH'ing to the deploy box and running \`scripts/create-api-key.ts\`.

## Test plan
- [x] \`npx vitest run src/__tests__/api/api-keys-routes\` — 15/15 pass (auth gates, validation, ownership checks, idempotency)
- [x] Full unit suite — 171/171 pass
- [x] \`npx tsc --noEmit\` clean
- [ ] **Manual**: log in → /dashboard/api-keys → create "Mira concierge bot" → see full key → copy → reload page → confirm full key is gone, only prefix remains
- [ ] **Manual**: revoke that key → confirm prompt → key shows "Revoked" badge → use it via curl → returns 401
- [ ] **Manual security**: in an incognito window with a different account, try \`POST /api/api-keys/<other-user-key-id>/revoke\` → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)