### PR TITLE
Reduce Google Calendar OAuth scope

### DIFF
--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -7,12 +7,24 @@ export async function GET() {
     return NextResponse.redirect(new URL("/login", process.env.NEXT_PUBLIC_APP_URL!))
   }
 
+  // Least-privilege scopes: identity (openid/email/profile) plus calendar.events,
+  // which is enough to read conflict events and create/update/delete booking events.
+  // Avoid the broader `auth/calendar` scope — it grants full calendar management
+  // (including deleting calendars) and triggers Google's "unverified app" warning
+  // with a scarier permission prompt than we need.
+  const scope = [
+    "openid",
+    "email",
+    "profile",
+    "https://www.googleapis.com/auth/calendar.events",
+  ].join(" ")
+
   // Build Google OAuth URL
   const params = new URLSearchParams({
     client_id: process.env.GOOGLE_CLIENT_ID!,
     redirect_uri: `${process.env.NEXT_PUBLIC_APP_URL}/api/auth/google/callback`,
     response_type: "code",
-    scope: "openid email profile https://www.googleapis.com/auth/calendar",
+    scope,
     access_type: "offline",
     prompt: "consent",
     state: user.id, // Pass user ID in state

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -380,6 +380,16 @@ export default function SettingsPage() {
           {/* Connect buttons */}
           {!limitReached && (
             <div className="space-y-2 mt-4">
+              <p className="text-xs text-gray-500 leading-relaxed">
+                Google may show an &ldquo;app hasn&rsquo;t been verified&rdquo;
+                screen while TinyCal&rsquo;s OAuth app is being verified by
+                Google. You can safely continue via{" "}
+                <span className="font-medium">Advanced &rarr; Go to TinyCal</span>.
+                TinyCal only requests calendar event access &mdash; used to
+                check your availability and create the events you accept as
+                bookings. We don&rsquo;t read or modify other calendar
+                settings.
+              </p>
               <button
                 onClick={connectGoogle}
                 className="w-full border-2 border-dashed rounded-lg p-3 text-sm text-gray-600 hover:bg-gray-50 transition"


### PR DESCRIPTION
## Summary
- narrow Google Calendar OAuth from full calendar management to `calendar.events`
- add inline settings copy explaining the temporary Google verification warning and what access TinyCal requests

## Verification
- `npm run lint` *(fails on pre-existing lint error: `src/app/api/meeting-links/[uid]/confirm/route.ts:179` unused `hostContactInfo`; warnings also pre-existing)*
- `npx tsc --noEmit` *(fails on pre-existing type errors in Stripe/auth/ui files; no new errors from this change)*
- `git diff --check` passed

## Notes
Google Cloud Console should also be updated to remove the broad `auth/calendar` scope and include `auth/calendar.events` so the OAuth consent configuration matches the app request.

Closes #49
