### PR TITLE
feat(event-type editor): show + allow editing the slug

### DIFF
--- a/src/__tests__/api/event-types-id.test.ts
+++ b/src/__tests__/api/event-types-id.test.ts
@@ -151,6 +151,75 @@ describe("PATCH /api/event-types/[id]", () => {
     )
     expect(mockUserCount).not.toHaveBeenCalled()
   })
+
+  describe("slug validation", () => {
+    beforeEach(() => {
+      mockEventTypeFindUnique.mockResolvedValue({ userId: OWNER.id })
+    })
+
+    it("accepts a valid slug", async () => {
+      const res = await PATCH(
+        new Request("http://x", { method: "PATCH", body: JSON.stringify({ slug: "discovery-call" }) }),
+        { params: { id: "et-1" } }
+      )
+      expect(res.status).toBe(200)
+      expect(mockEventTypeUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ slug: "discovery-call" }) })
+      )
+    })
+
+    it("rejects empty slug", async () => {
+      const res = await PATCH(
+        new Request("http://x", { method: "PATCH", body: JSON.stringify({ slug: "" }) }),
+        { params: { id: "et-1" } }
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it("rejects slug with uppercase, underscores, or spaces", async () => {
+      for (const bad of ["BadSlug", "bad_slug", "bad slug", "-bad", "bad-", "bad--slug"]) {
+        mockEventTypeFindUnique.mockResolvedValueOnce({ userId: OWNER.id })
+        const res = await PATCH(
+          new Request("http://x", { method: "PATCH", body: JSON.stringify({ slug: bad }) }),
+          { params: { id: "et-1" } }
+        )
+        expect(res.status, `slug=${bad} should fail`).toBe(400)
+      }
+    })
+
+    it("rejects slug over 80 chars", async () => {
+      const res = await PATCH(
+        new Request("http://x", { method: "PATCH", body: JSON.stringify({ slug: "a".repeat(81) }) }),
+        { params: { id: "et-1" } }
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it("returns friendly 409 on Prisma P2002 (duplicate slug)", async () => {
+      const { Prisma } = await import("@prisma/client")
+      mockEventTypeUpdate.mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint violated", {
+          code: "P2002", clientVersion: "5.22.0",
+        })
+      )
+
+      const res = await PATCH(
+        new Request("http://x", { method: "PATCH", body: JSON.stringify({ slug: "discovery-call" }) }),
+        { params: { id: "et-1" } }
+      )
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.error).toContain("already have an event type with this slug")
+    })
+
+    it("ignores slug entirely when not provided in body", async () => {
+      const res = await PATCH(
+        new Request("http://x", { method: "PATCH", body: JSON.stringify({ title: "Just a rename" }) }),
+        { params: { id: "et-1" } }
+      )
+      expect(res.status).toBe(200)
+    })
+  })
 })
 
 describe("DELETE /api/event-types/[id]", () => {

--- a/src/app/api/event-types/[id]/route.ts
+++ b/src/app/api/event-types/[id]/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server"
+import { Prisma } from "@prisma/client"
 import { getAuthenticatedUser } from "@/lib/auth"
 import prisma from "@/lib/prisma"
+
+// URL-safe slug. Lowercase letters, digits, hyphens. No leading/trailing
+// hyphen. 1–80 chars. Mirrors what the public booking-page route can resolve.
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const MAX_SLUG_LENGTH = 80
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const user = await getAuthenticatedUser()
@@ -58,29 +64,57 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     }
   }
 
-  const eventType = await prisma.eventType.update({
-    where: { id: params.id },
-    data: {
-      title: body.title,
-      description: body.description,
-      duration: body.duration,
-      location: body.location,
-      customLocation: body.customLocation,
-      color: body.color,
-      active: body.active,
-      bufferBefore: body.bufferBefore,
-      bufferAfter: body.bufferAfter,
-      dailyLimit: body.dailyLimit,
-      weeklyLimit: body.weeklyLimit,
-      minNotice: body.minNotice,
-      maxFutureDays: body.maxFutureDays,
-      requirePayment: body.requirePayment,
-      price: body.price,
-      isCollective: body.isCollective,
-      collectiveMembers: body.collectiveMembers,
-    },
-  })
-  return NextResponse.json(eventType)
+  if (typeof body.slug === "string") {
+    if (body.slug.length === 0 || body.slug.length > MAX_SLUG_LENGTH) {
+      return NextResponse.json(
+        { error: `slug must be 1–${MAX_SLUG_LENGTH} characters` },
+        { status: 400 }
+      )
+    }
+    if (!SLUG_PATTERN.test(body.slug)) {
+      return NextResponse.json(
+        { error: "slug must contain only lowercase letters, digits, and single hyphens (no leading/trailing hyphens)" },
+        { status: 400 }
+      )
+    }
+  }
+
+  try {
+    const eventType = await prisma.eventType.update({
+      where: { id: params.id },
+      data: {
+        title: body.title,
+        slug: body.slug,
+        description: body.description,
+        duration: body.duration,
+        location: body.location,
+        customLocation: body.customLocation,
+        color: body.color,
+        active: body.active,
+        bufferBefore: body.bufferBefore,
+        bufferAfter: body.bufferAfter,
+        dailyLimit: body.dailyLimit,
+        weeklyLimit: body.weeklyLimit,
+        minNotice: body.minNotice,
+        maxFutureDays: body.maxFutureDays,
+        requirePayment: body.requirePayment,
+        price: body.price,
+        isCollective: body.isCollective,
+        collectiveMembers: body.collectiveMembers,
+      },
+    })
+    return NextResponse.json(eventType)
+  } catch (e) {
+    // Unique constraint on @@unique([userId, slug]) — surface a friendly error
+    // instead of leaking the Prisma error shape.
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      return NextResponse.json(
+        { error: "You already have an event type with this slug — pick a different one" },
+        { status: 409 }
+      )
+    }
+    throw e
+  }
 }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {

--- a/src/app/dashboard/event-types/[id]/page.tsx
+++ b/src/app/dashboard/event-types/[id]/page.tsx
@@ -11,29 +11,74 @@ interface CoHost {
   email: string | null
 }
 
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+function validateSlug(s: string): string | null {
+  if (s.length === 0) return "Slug can't be empty"
+  if (s.length > 80) return "Slug must be 80 characters or fewer"
+  if (!SLUG_PATTERN.test(s)) {
+    return "Slug must be lowercase letters, digits, and single hyphens (no leading/trailing)"
+  }
+  return null
+}
+
 export default function EditEventTypePage() {
   const params = useParams()
   const router = useRouter()
   const [et, setEt] = useState<any>(null)
+  const [originalSlug, setOriginalSlug] = useState<string>("")
+  const [userSlug, setUserSlug] = useState<string>("")
   const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   const [coHostEmail, setCoHostEmail] = useState("")
   const [coHostError, setCoHostError] = useState<string | null>(null)
   const [coHostAdding, setCoHostAdding] = useState(false)
 
   useEffect(() => {
-    fetch(`/api/event-types/${params.id}`).then(r => r.json()).then(setEt)
+    fetch(`/api/event-types/${params.id}`).then(r => r.json()).then(data => {
+      setEt(data)
+      setOriginalSlug(data.slug ?? "")
+    })
+    fetch("/api/user").then(r => r.json()).then(u => setUserSlug(u?.slug ?? ""))
   }, [params.id])
 
+  const slugError = et?.slug != null ? validateSlug(et.slug) : null
+  const slugChanged = et != null && et.slug !== originalSlug
+
   async function handleSave() {
+    setSaveError(null)
+
+    if (slugError) {
+      setSaveError(slugError)
+      return
+    }
+
+    if (slugChanged) {
+      const ok = confirm(
+        `Changing the slug from "${originalSlug}" to "${et.slug}" will break any existing booking links you've shared. Existing bookings keep working — only future links are affected.\n\nContinue?`
+      )
+      if (!ok) return
+    }
+
     setSaving(true)
-    await fetch(`/api/event-types/${params.id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(et),
-    })
-    setSaving(false)
-    router.push("/dashboard/event-types")
+    try {
+      const res = await fetch(`/api/event-types/${params.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(et),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setSaveError(body.error || `Save failed (HTTP ${res.status})`)
+        return
+      }
+      router.push("/dashboard/event-types")
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Network error")
+    } finally {
+      setSaving(false)
+    }
   }
 
   async function addCoHost() {
@@ -83,6 +128,9 @@ export default function EditEventTypePage() {
   const showsEmptyCollectiveWarning =
     et.isCollective && (et.collectiveMembers ?? []).length === 0
 
+  const previewHost = typeof window !== "undefined" ? window.location.host : "tinycal.zenithstudio.app"
+  const slugUrlPreview = userSlug ? `${previewHost}/${userSlug}/${et.slug}` : null
+
   return (
     <div>
       <div className="flex items-center gap-3 mb-6">
@@ -93,12 +141,35 @@ export default function EditEventTypePage() {
       </div>
 
       <div className="bg-white border rounded-xl p-6 space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium mb-1">Title</label>
-            <input type="text" value={et.title} onChange={e => setEt({ ...et, title: e.target.value })}
-              className="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 outline-none" />
+        <div>
+          <label className="block text-sm font-medium mb-1">Title</label>
+          <input type="text" value={et.title} onChange={e => setEt({ ...et, title: e.target.value })}
+            className="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 outline-none" />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Slug</label>
+          <input
+            type="text"
+            value={et.slug ?? ""}
+            onChange={e => setEt({ ...et, slug: e.target.value })}
+            placeholder="discovery-call"
+            className={`w-full border rounded-lg px-3 py-2 font-mono text-sm focus:ring-2 focus:ring-blue-500 outline-none ${slugError ? "border-red-300" : ""}`}
+          />
+          <div className="text-xs text-gray-500 mt-1 flex items-center gap-1">
+            {slugUrlPreview ? <>Booking page: <code className="text-gray-700">{slugUrlPreview}</code></> : "Used in the booking page URL and the API"}
           </div>
+          {slugError && (
+            <div className="text-xs text-red-700 mt-1">{slugError}</div>
+          )}
+          {slugChanged && !slugError && (
+            <div className="text-xs text-amber-700 mt-1">
+              Changing the slug will break any links you&apos;ve already shared.
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div>
             <label className="block text-sm font-medium mb-1">Duration (min)</label>
             <select value={et.duration} onChange={e => setEt({ ...et, duration: Number(e.target.value) })}
@@ -263,8 +334,14 @@ export default function EditEventTypePage() {
           <label htmlFor="active" className="text-sm">Active (visible on booking page)</label>
         </div>
 
+        {saveError && (
+          <div className="text-sm text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2">
+            {saveError}
+          </div>
+        )}
+
         <div className="flex justify-end">
-          <button onClick={handleSave} disabled={saving}
+          <button onClick={handleSave} disabled={saving || !!slugError}
             className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2">
             <Save className="w-4 h-4" /> {saving ? "Saving..." : "Save Changes"}
           </button>


### PR DESCRIPTION
Closes #52.

## Summary
- Slug input with URL preview underneath (\`tinycal.zenithstudio.app/<user-slug>/<slug>\`)
- Inline format validation (lowercase + digits + single hyphens, 1–80)
- Confirm dialog on save when the slug actually changed (since it breaks any shared links)
- Server-side validation + friendly 409 on Prisma P2002 (duplicate slug)

## Why
The slug ends up in the public booking URL, the \`?slug=\` filter on \`/api/v1/event-types\`, and the \`eventType.slug\` field in webhook payloads — but it had no UI surface. Discovered while answering "where do I find the event type slug?" during the Mira prep (#33).

## Bonus
While in the editor, also fixed a small pre-existing gap: the original \`handleSave\` ignored response status, so a failed PATCH silently looked successful. Now surfaces \`saveError\` and disables the save button while the slug is invalid.

## Test plan
- [x] \`npx vitest run src/__tests__/api/event-types-id\` — 16/16 pass (added 6 new cases for slug)
- [x] Full unit suite — 193/193 pass
- [x] \`npx tsc --noEmit\` clean
- [ ] **Manual**: edit your discovery-call event type → see slug field with current value and URL preview
- [ ] **Manual**: type \`BadSlug\` → inline error, save button disabled
- [ ] **Manual**: change to a valid new slug → amber warning shows → click Save → confirm dialog → confirm → reload → slug persists, booking page is at the new URL
- [ ] **Manual**: try to set the slug to something another of your event types already uses → 409 banner with friendly message

🤖 Generated with [Claude Code](https://claude.com/claude-code)