### PR TITLE
fix(security): close ownership-check gaps on /api/* mutation endpoints

### DIFF
--- a/src/__tests__/api/calendar-connections-routes.test.ts
+++ b/src/__tests__/api/calendar-connections-routes.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockFindUnique = vi.fn()
+const mockUpdate = vi.fn()
+const mockDelete = vi.fn()
+const mockUpdateMany = vi.fn()
+const mockCount = vi.fn()
+const mockFindFirst = vi.fn()
+const mockGetAuthenticatedUser = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    calendarConnection: {
+      findUnique: (...args: any[]) => mockFindUnique(...args),
+      update: (...args: any[]) => mockUpdate(...args),
+      delete: (...args: any[]) => mockDelete(...args),
+      updateMany: (...args: any[]) => mockUpdateMany(...args),
+      count: (...args: any[]) => mockCount(...args),
+      findFirst: (...args: any[]) => mockFindFirst(...args),
+    },
+  },
+}))
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: (...args: any[]) => mockGetAuthenticatedUser(...args),
+}))
+
+import { PATCH, DELETE } from "@/app/api/calendar-connections/[id]/route"
+
+const OWNER = { id: "owner-1" } as any
+const OTHER = { id: "other-1" } as any
+
+describe("PATCH /api/calendar-connections/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+  })
+
+  it("returns 403 (not 401) when connection belongs to another user", async () => {
+    mockFindUnique.mockResolvedValueOnce({ userId: OTHER.id })
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: "{}" }),
+      { params: { id: "conn-1" } }
+    )
+    expect(res.status).toBe(403)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it("returns 404 when connection does not exist", async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: "{}" }),
+      { params: { id: "conn-1" } }
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("happy path: PATCH succeeds for owner", async () => {
+    mockFindUnique.mockResolvedValueOnce({ userId: OWNER.id, isPrimary: false })
+    mockUpdate.mockResolvedValueOnce({ id: "conn-1" })
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: JSON.stringify({ label: "Work" }) }),
+      { params: { id: "conn-1" } }
+    )
+    expect(res.status).toBe(200)
+    expect(mockUpdate).toHaveBeenCalled()
+  })
+})
+
+describe("DELETE /api/calendar-connections/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+  })
+
+  it("returns 403 when connection belongs to another user", async () => {
+    mockFindUnique.mockResolvedValueOnce({ userId: OTHER.id })
+    const res = await DELETE(new Request("http://x"), { params: { id: "conn-1" } })
+    expect(res.status).toBe(403)
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it("returns 404 when connection does not exist", async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+    const res = await DELETE(new Request("http://x"), { params: { id: "conn-1" } })
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 400 when trying to delete the last connection", async () => {
+    mockFindUnique.mockResolvedValueOnce({ userId: OWNER.id, isPrimary: false })
+    mockCount.mockResolvedValueOnce(1)
+    const res = await DELETE(new Request("http://x"), { params: { id: "conn-1" } })
+    expect(res.status).toBe(400)
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it("happy path: DELETE succeeds and promotes oldest as new primary if deleted was primary", async () => {
+    mockFindUnique.mockResolvedValueOnce({ userId: OWNER.id, isPrimary: true })
+    mockCount.mockResolvedValueOnce(2)
+    mockDelete.mockResolvedValueOnce({})
+    mockFindFirst.mockResolvedValueOnce({ id: "conn-2" })
+    mockUpdate.mockResolvedValueOnce({})
+    const res = await DELETE(new Request("http://x"), { params: { id: "conn-1" } })
+    expect(res.status).toBe(200)
+    expect(mockDelete).toHaveBeenCalled()
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: "conn-2" },
+      data: { isPrimary: true },
+    })
+  })
+})

--- a/src/__tests__/api/webhooks-routes.test.ts
+++ b/src/__tests__/api/webhooks-routes.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockWebhookFindUnique = vi.fn()
+const mockWebhookDelete = vi.fn()
+const mockGetAuthenticatedUser = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    webhook: {
+      findMany: vi.fn(),
+      findUnique: (...args: any[]) => mockWebhookFindUnique(...args),
+      create: vi.fn(),
+      delete: (...args: any[]) => mockWebhookDelete(...args),
+    },
+  },
+}))
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: (...args: any[]) => mockGetAuthenticatedUser(...args),
+}))
+
+import { DELETE } from "@/app/api/webhooks/route"
+
+const OWNER = { id: "owner-1" } as any
+const OTHER = { id: "other-1" } as any
+
+function makeReq(body: unknown): Request {
+  return new Request("http://x/api/webhooks", {
+    method: "DELETE",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  })
+}
+
+describe("DELETE /api/webhooks (ownership audit, #55)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+  })
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(null)
+    const res = await DELETE(makeReq({ id: "wh-1" }))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 400 when id is missing or not a string", async () => {
+    expect((await DELETE(makeReq({}))).status).toBe(400)
+    expect((await DELETE(makeReq({ id: 123 }))).status).toBe(400)
+  })
+
+  it("returns 404 for unknown webhook id", async () => {
+    mockWebhookFindUnique.mockResolvedValueOnce(null)
+    const res = await DELETE(makeReq({ id: "wh-1" }))
+    expect(res.status).toBe(404)
+    expect(mockWebhookDelete).not.toHaveBeenCalled()
+  })
+
+  it("returns 403 when deleting someone else's webhook", async () => {
+    mockWebhookFindUnique.mockResolvedValueOnce({ userId: OTHER.id })
+    const res = await DELETE(makeReq({ id: "wh-1" }))
+    expect(res.status).toBe(403)
+    expect(mockWebhookDelete).not.toHaveBeenCalled()
+  })
+
+  it("deletes successfully when owner", async () => {
+    mockWebhookFindUnique.mockResolvedValueOnce({ userId: OWNER.id })
+    mockWebhookDelete.mockResolvedValueOnce({})
+    const res = await DELETE(makeReq({ id: "wh-1" }))
+    expect(res.status).toBe(200)
+    expect(mockWebhookDelete).toHaveBeenCalledWith({ where: { id: "wh-1" } })
+  })
+})

--- a/src/app/api/calendar-connections/[id]/route.ts
+++ b/src/app/api/calendar-connections/[id]/route.ts
@@ -51,7 +51,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     return NextResponse.json({ error: "Calendar connection not found" }, { status: 404 })
   }
   if (connection.userId !== userId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
 
   const body = await req.json()
@@ -125,7 +125,7 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     return NextResponse.json({ error: "Calendar connection not found" }, { status: 404 })
   }
   if (connection.userId !== userId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
 
   // Cannot disconnect the last calendar

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -34,6 +34,21 @@ export async function DELETE(req: Request) {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   const { id } = await req.json()
+  if (!id || typeof id !== "string") {
+    return NextResponse.json({ error: "id is required" }, { status: 400 })
+  }
+
+  // Ownership check — without this, any authed user could delete any other
+  // user's webhook by guessing the cuid (#55).
+  const existing = await prisma.webhook.findUnique({
+    where: { id },
+    select: { userId: true },
+  })
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  if (existing.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
   await prisma.webhook.delete({ where: { id } })
   return NextResponse.json({ success: true })
 }


### PR DESCRIPTION
Closes #55.

## Audit findings
Went through every \`/api/*\` route that calls \`prisma.<model>.update\` or \`.delete\`. Two real bugs and one consistency fix.

### Real bugs

**\`/api/webhooks\` DELETE** — no ownership check. Any authenticated user could delete any other user's webhook by guessing the cuid. (cuids leak in URLs, webhook payloads, and API responses.)
\`\`\`ts
// before
const { id } = await req.json()
await prisma.webhook.delete({ where: { id } })
\`\`\`
Now: \`findUnique\` first → 404 if missing, 403 if owned by someone else, then delete.

### Consistency fix

**\`/api/calendar-connections/[id]\` PATCH/DELETE** — already had ownership checks but returned **401** on mismatch. The user IS authenticated, just not authorized — should be **403**. Brought in line with \`/api/event-types/[id]\`, \`/api/api-keys/[id]/revoke\`, and now \`/api/webhooks\`.

## Audited and confirmed safe (no change)
- \`/api/event-types/[id]\` PATCH/DELETE — fixed in #47
- \`/api/api-keys/[id]/revoke\` POST — fixed in #48
- \`/api/availability\` PUT — scoped to \`user.id\` (deleteMany + createMany with the requester's id; can't touch other users)
- \`/api/event-types\` POST, \`/api/api-keys\` POST, \`/api/meeting-links\` POST — all create with \`user.id\` (and meeting-links verifies eventType ownership via findFirst)

## Out of scope (different threat model)
The public \`uid\`-as-token routes — anyone with the link can act, by design:
- \`/api/bookings/[uid]/{cancel,reschedule}\`
- \`/api/meeting-links/[uid]/{confirm,ics}\` and the GET

## Test plan
- [x] 5 new tests on webhooks DELETE (auth, body validation, 404, 403, happy)
- [x] 7 new tests on calendar-connections PATCH/DELETE (incl. the 401→403 case)
- [x] Full unit suite — 199/199 pass
- [ ] Manual: as user A, \`curl -X DELETE -d '{"id":"<userB-webhook-id>"}' /api/webhooks\` → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)