### PR TITLE
feat(api/v1): idempotent POST /api/v1/bookings via Idempotency-Key header

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Per-key rate limit: **60 requests/minute**. Responses include
 
 #### Bookings
 - `GET /api/v1/bookings` — List bookings (supports `?status=`, `?from=`, `?to=` filters)
-- `POST /api/v1/bookings` — Create a booking on one of your event types. Body: `{ eventTypeId, startTime (ISO 8601), bookerName, bookerEmail, bookerTimezone, bookerPhone?, answers? }`. Returns `201` with `{ data: <booking> }` including `meetingUrl`. The event type must belong to the API key's owner (otherwise `403`).
+- `POST /api/v1/bookings` — Create a booking on one of your event types. Body: `{ eventTypeId, startTime (ISO 8601), bookerName, bookerEmail, bookerTimezone, bookerPhone?, answers? }`. Returns `201` with `{ data: <booking> }` including `meetingUrl`. The event type must belong to the API key's owner (otherwise `403`). Pass `Idempotency-Key: <opaque>` (e.g. UUID) to safely retry on network errors — repeats with the same key + body within 24h replay the original response (with `X-Idempotent-Replay: true` header); same key + different body returns `409`.
 
 #### Calendar Connections
 - `PATCH /api/calendar-connections/:id` — Update connection settings (label, checkConflicts, isPrimary)

--- a/prisma/migrations/20260510000000_add_idempotency_key/migration.sql
+++ b/prisma/migrations/20260510000000_add_idempotency_key/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "IdempotencyKey" (
+    "id" TEXT NOT NULL,
+    "apiKeyId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "requestHash" TEXT NOT NULL,
+    "responseStatus" INTEGER NOT NULL,
+    "responseBody" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IdempotencyKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IdempotencyKey_apiKeyId_key_key" ON "IdempotencyKey"("apiKeyId", "key");
+
+-- CreateIndex
+CREATE INDEX "IdempotencyKey_createdAt_idx" ON "IdempotencyKey"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "IdempotencyKey" ADD CONSTRAINT "IdempotencyKey_apiKeyId_fkey" FOREIGN KEY ("apiKeyId") REFERENCES "ApiKey"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -281,8 +281,9 @@ model ApiKey {
   revokedAt    DateTime?
   createdAt    DateTime  @default(now())
 
-  user  User           @relation(fields: [userId], references: [id], onDelete: Cascade)
-  usage ApiKeyUsage[]
+  user             User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  usage            ApiKeyUsage[]
+  idempotencyKeys  IdempotencyKey[]
 
   @@index([userId])
 }
@@ -299,6 +300,26 @@ model ApiKeyUsage {
 
   @@unique([apiKeyId, windowStart])
   @@index([windowStart])
+}
+
+// Idempotency cache for /api/v1/* mutating endpoints. Scoped per API key so
+// the same Idempotency-Key value from two different bots can't collide.
+// Only successful responses are cached (clients should be free to retry on
+// failure with the same key). Stale rows (>24h) are treated as not-found and
+// can be pruned by cron.
+model IdempotencyKey {
+  id             String   @id @default(cuid())
+  apiKeyId       String
+  key            String
+  requestHash    String   // sha256(canonicalJson(body))
+  responseStatus Int
+  responseBody   Json
+  createdAt      DateTime @default(now())
+
+  apiKey ApiKey @relation(fields: [apiKeyId], references: [id], onDelete: Cascade)
+
+  @@unique([apiKeyId, key])
+  @@index([createdAt])
 }
 
 // ─── Documents (E-Signature - schema ready for Module 2) ───

--- a/scripts/recover-failed-migration.ts
+++ b/scripts/recover-failed-migration.ts
@@ -21,9 +21,9 @@ async function main() {
   const prisma = new PrismaClient()
   try {
     // Safety check — refuse to drop a table that has rows
-    const rowCount: Array<{ count: bigint }> = await prisma.$queryRawUnsafe(
+    const rowCount = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
       `SELECT COUNT(*)::bigint AS count FROM "AvailabilitySchedule"`
-    ).catch(() => [{ count: BigInt(-1) }])
+    ).catch(() => [{ count: BigInt(-1) }] as Array<{ count: bigint }>)
 
     if (rowCount[0].count === BigInt(-1)) {
       console.log("AvailabilitySchedule does not exist — nothing to drop. Proceeding to mark rolled-back.")

--- a/src/__tests__/api/v1-bookings.test.ts
+++ b/src/__tests__/api/v1-bookings.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 const mockBookingFindMany = vi.fn()
 const mockCreateBooking = vi.fn()
 const mockAuthenticateApiKey = vi.fn()
+const mockLookupIdempotency = vi.fn()
+const mockRecordIdempotentResponse = vi.fn()
 
 vi.mock("@/lib/prisma", () => ({
   default: {
@@ -25,6 +27,15 @@ vi.mock("@/lib/api-keys/auth", () => ({
   applyAuthResponseHeaders: (res: any) => res,
 }))
 
+vi.mock("@/lib/api-keys/idempotency", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-keys/idempotency")>()
+  return {
+    ...actual,
+    lookupIdempotency: (...args: any[]) => mockLookupIdempotency(...args),
+    recordIdempotentResponse: (...args: any[]) => mockRecordIdempotentResponse(...args),
+  }
+})
+
 import { POST } from "@/app/api/v1/bookings/route"
 
 const TEST_USER = { id: "user-1", email: "x@y.z", name: "X" } as any
@@ -36,10 +47,14 @@ const VALID_BODY = {
   bookerTimezone: "America/Los_Angeles",
 }
 
-function makePostReq(body: unknown): Request {
+function makePostReq(body: unknown, headers: Record<string, string> = {}): Request {
   return new Request("http://localhost/api/v1/bookings", {
     method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: "Bearer fake" },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer fake",
+      ...headers,
+    },
     body: typeof body === "string" ? body : JSON.stringify(body),
   })
 }
@@ -133,6 +148,66 @@ describe("POST /api/v1/bookings", () => {
       expect(res.status).toBe(201)
       const body = await res.json()
       expect(body).toEqual({ data: { id: "bk-1", meetingUrl: "https://meet/x" } })
+    })
+  })
+
+  describe("idempotency (#53)", () => {
+    beforeEach(() => {
+      mockLookupIdempotency.mockResolvedValue({ kind: "miss" })
+      mockRecordIdempotentResponse.mockResolvedValue(undefined)
+    })
+
+    it("does NOT call lookupIdempotency when no Idempotency-Key header is present", async () => {
+      await POST(makePostReq(VALID_BODY))
+      expect(mockLookupIdempotency).not.toHaveBeenCalled()
+      expect(mockRecordIdempotentResponse).not.toHaveBeenCalled()
+    })
+
+    it("calls lookupIdempotency with (apiKeyId, key, hash) when header is present", async () => {
+      await POST(makePostReq(VALID_BODY, { "Idempotency-Key": "abc-123" }))
+      expect(mockLookupIdempotency).toHaveBeenCalledWith("ak-1", "abc-123", expect.stringMatching(/^[0-9a-f]{64}$/))
+    })
+
+    it("returns the cached response on replay (does not call createBooking)", async () => {
+      const cached = new Response(JSON.stringify({ data: { id: "bk-original" } }), {
+        status: 201,
+        headers: { "Content-Type": "application/json", "X-Idempotent-Replay": "true" },
+      })
+      mockLookupIdempotency.mockResolvedValueOnce({ kind: "replay", response: cached })
+      const res = await POST(makePostReq(VALID_BODY, { "Idempotency-Key": "abc-123" }))
+      expect(res.status).toBe(201)
+      expect(res.headers.get("X-Idempotent-Replay")).toBe("true")
+      expect(mockCreateBooking).not.toHaveBeenCalled()
+    })
+
+    it("returns 409 on body-mismatch with the same key", async () => {
+      mockLookupIdempotency.mockResolvedValueOnce({ kind: "mismatch" })
+      const res = await POST(makePostReq(VALID_BODY, { "Idempotency-Key": "abc-123" }))
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.error).toContain("Idempotency-Key")
+      expect(mockCreateBooking).not.toHaveBeenCalled()
+    })
+
+    it("records the response after a successful createBooking", async () => {
+      await POST(makePostReq(VALID_BODY, { "Idempotency-Key": "abc-123" }))
+      expect(mockRecordIdempotentResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKeyId: "ak-1",
+          idempotencyKey: "abc-123",
+          responseStatus: 201,
+        })
+      )
+    })
+
+    it("does NOT record on createBooking failure (clients should be able to retry)", async () => {
+      mockCreateBooking.mockResolvedValueOnce({ ok: false, error: "CONFLICT", status: 409 })
+      await POST(makePostReq(VALID_BODY, { "Idempotency-Key": "abc-123" }))
+      // recordIdempotentResponse is called but with a non-2xx status; the helper
+      // itself drops it. Here we assert the route forwards the failure status:
+      expect(mockRecordIdempotentResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ responseStatus: 409 })
+      )
     })
   })
 })

--- a/src/app/api/v1/bookings/route.ts
+++ b/src/app/api/v1/bookings/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import prisma from "@/lib/prisma"
 import { authenticateApiKey, isAuthFailure, applyAuthResponseHeaders } from "@/lib/api-keys/auth"
 import { createBooking } from "@/lib/bookings/create"
+import { hashRequestBody, lookupIdempotency, recordIdempotentResponse } from "@/lib/api-keys/idempotency"
 
 export async function GET(req: Request) {
   const auth = await authenticateApiKey(req)
@@ -56,25 +57,61 @@ export async function POST(req: Request) {
     )
   }
 
+  // ── Idempotency ──
+  // Bot retry safety: if the same Idempotency-Key arrives twice with the same
+  // body within 24h, return the cached response instead of re-executing.
+  const idempotencyKey = req.headers.get("Idempotency-Key")?.trim() || null
+  const requestHash = idempotencyKey ? hashRequestBody(parsed.data) : null
+
+  if (idempotencyKey && requestHash && auth.apiKeyId) {
+    const lookup = await lookupIdempotency(auth.apiKeyId, idempotencyKey, requestHash)
+    if (lookup.kind === "replay") {
+      return applyAuthResponseHeaders(lookup.response, auth)
+    }
+    if (lookup.kind === "mismatch") {
+      return applyAuthResponseHeaders(
+        NextResponse.json(
+          { error: "Idempotency-Key was previously used with a different request body" },
+          { status: 409 }
+        ),
+        auth
+      )
+    }
+    // miss → fall through and execute
+  }
+
   const result = await createBooking({
     ...parsed.data,
     requireOwnerUserId: auth.user.id,
   })
 
+  let responseStatus: number
+  let responseBody: Record<string, unknown>
   if (!result.ok) {
     const messages: Record<typeof result.error, string> = {
       EVENT_TYPE_NOT_FOUND: "Event type not found",
       FORBIDDEN: "Event type does not belong to this API key's owner",
       CONFLICT: "Time slot no longer available",
     }
-    return applyAuthResponseHeaders(
-      NextResponse.json({ error: messages[result.error] }, { status: result.status }),
-      auth
-    )
+    responseStatus = result.status
+    responseBody = { error: messages[result.error] }
+  } else {
+    responseStatus = 201
+    responseBody = { data: result.booking }
+  }
+
+  if (idempotencyKey && requestHash && auth.apiKeyId) {
+    await recordIdempotentResponse({
+      apiKeyId: auth.apiKeyId,
+      idempotencyKey,
+      requestHash,
+      responseStatus,
+      responseBody,
+    })
   }
 
   return applyAuthResponseHeaders(
-    NextResponse.json({ data: result.booking }, { status: 201 }),
+    NextResponse.json(responseBody, { status: responseStatus }),
     auth
   )
 }

--- a/src/lib/api-keys/__tests__/idempotency.test.ts
+++ b/src/lib/api-keys/__tests__/idempotency.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { canonicalJson, hashRequestBody, lookupIdempotency, recordIdempotentResponse, IDEMPOTENCY_TTL_MS } from "../idempotency"
+
+const mockFindUnique = vi.fn()
+const mockCreate = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    idempotencyKey: {
+      findUnique: (...args: any[]) => mockFindUnique(...args),
+      create: (...args: any[]) => mockCreate(...args),
+      delete: (...args: any[]) => mockDelete(...args),
+    },
+  },
+}))
+
+describe("canonicalJson", () => {
+  it("sorts object keys recursively (so different orderings hash the same)", () => {
+    expect(canonicalJson({ a: 1, b: 2 })).toBe(canonicalJson({ b: 2, a: 1 }))
+    expect(canonicalJson({ x: { a: 1, b: 2 } })).toBe(canonicalJson({ x: { b: 2, a: 1 } }))
+  })
+
+  it("preserves array order", () => {
+    expect(canonicalJson([1, 2, 3])).toBe("[1,2,3]")
+    expect(canonicalJson([1, 2, 3])).not.toBe(canonicalJson([3, 2, 1]))
+  })
+
+  it("handles primitives + null", () => {
+    expect(canonicalJson(null)).toBe("null")
+    expect(canonicalJson(42)).toBe("42")
+    expect(canonicalJson("foo")).toBe('"foo"')
+    expect(canonicalJson(true)).toBe("true")
+  })
+})
+
+describe("hashRequestBody", () => {
+  it("returns the same hex hash for objects with reordered keys", () => {
+    expect(hashRequestBody({ a: 1, b: 2 })).toBe(hashRequestBody({ b: 2, a: 1 }))
+  })
+
+  it("returns a 64-char hex string", () => {
+    expect(hashRequestBody({ x: 1 })).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+describe("lookupIdempotency", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const HASH = hashRequestBody({ x: 1 })
+
+  it("returns miss when no row exists", async () => {
+    mockFindUnique.mockResolvedValueOnce(null)
+    const result = await lookupIdempotency("ak-1", "key-1", HASH)
+    expect(result.kind).toBe("miss")
+  })
+
+  it("returns mismatch when stored row has a different requestHash", async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: "ik-1", requestHash: "different-hash",
+      responseStatus: 201, responseBody: {},
+      createdAt: new Date(),
+    })
+    const result = await lookupIdempotency("ak-1", "key-1", HASH)
+    expect(result.kind).toBe("mismatch")
+  })
+
+  it("returns replay with the cached response when hash matches and not stale", async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: "ik-1", requestHash: HASH,
+      responseStatus: 201, responseBody: { data: { id: "bk-1" } },
+      createdAt: new Date(),
+    })
+    const result = await lookupIdempotency("ak-1", "key-1", HASH)
+    expect(result.kind).toBe("replay")
+    if (result.kind === "replay") {
+      expect(result.response.status).toBe(201)
+      expect(result.response.headers.get("X-Idempotent-Replay")).toBe("true")
+      const body = await result.response.json()
+      expect(body).toEqual({ data: { id: "bk-1" } })
+    }
+  })
+
+  it("treats rows older than TTL as miss and deletes them", async () => {
+    const stale = new Date(Date.now() - IDEMPOTENCY_TTL_MS - 1000)
+    mockFindUnique.mockResolvedValueOnce({
+      id: "ik-1", requestHash: HASH,
+      responseStatus: 201, responseBody: {},
+      createdAt: stale,
+    })
+    mockDelete.mockResolvedValueOnce({})
+    const result = await lookupIdempotency("ak-1", "key-1", HASH)
+    expect(result.kind).toBe("miss")
+    expect(mockDelete).toHaveBeenCalled()
+  })
+})
+
+describe("recordIdempotentResponse", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("persists 2xx responses", async () => {
+    mockCreate.mockResolvedValueOnce({})
+    await recordIdempotentResponse({
+      apiKeyId: "ak-1",
+      idempotencyKey: "key-1",
+      requestHash: "hash",
+      responseStatus: 201,
+      responseBody: { data: {} },
+    })
+    expect(mockCreate).toHaveBeenCalled()
+  })
+
+  it("does NOT persist non-2xx responses (so clients can retry)", async () => {
+    await recordIdempotentResponse({
+      apiKeyId: "ak-1",
+      idempotencyKey: "key-1",
+      requestHash: "hash",
+      responseStatus: 409,
+      responseBody: { error: "conflict" },
+    })
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it("swallows P2002 race losses (logged, not thrown)", async () => {
+    const { Prisma } = await import("@prisma/client")
+    mockCreate.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint", {
+        code: "P2002", clientVersion: "5.22.0",
+      })
+    )
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    await expect(recordIdempotentResponse({
+      apiKeyId: "ak-1",
+      idempotencyKey: "key-1",
+      requestHash: "hash",
+      responseStatus: 201,
+      responseBody: { data: {} },
+    })).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it("re-throws non-P2002 Prisma errors", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("connection lost"))
+    await expect(recordIdempotentResponse({
+      apiKeyId: "ak-1",
+      idempotencyKey: "key-1",
+      requestHash: "hash",
+      responseStatus: 201,
+      responseBody: { data: {} },
+    })).rejects.toThrow("connection lost")
+  })
+})

--- a/src/lib/api-keys/idempotency.ts
+++ b/src/lib/api-keys/idempotency.ts
@@ -1,0 +1,96 @@
+import crypto from "crypto"
+import { Prisma } from "@prisma/client"
+import { NextResponse } from "next/server"
+import prisma from "@/lib/prisma"
+
+export const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000  // 24h
+
+// Deterministic JSON serialization — sorts object keys recursively so that
+// {a:1,b:2} and {b:2,a:1} produce the same hash. Critical for the
+// "same key, same body" check to behave correctly.
+export function canonicalJson(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v)
+  if (Array.isArray(v)) return "[" + v.map(canonicalJson).join(",") + "]"
+  const keys = Object.keys(v as object).sort()
+  return "{" + keys.map(k => JSON.stringify(k) + ":" + canonicalJson((v as Record<string, unknown>)[k])).join(",") + "}"
+}
+
+export function hashRequestBody(body: unknown): string {
+  return crypto.createHash("sha256").update(canonicalJson(body)).digest("hex")
+}
+
+export type IdempotencyLookup =
+  | { kind: "miss" }
+  | { kind: "replay"; response: NextResponse }
+  | { kind: "mismatch" }
+
+// Check whether this Idempotency-Key has been used before for this API key.
+// Returns:
+//   - "miss"       — proceed with the handler, then call recordIdempotentResponse on success
+//   - "replay"     — return the cached response verbatim, with X-Idempotent-Replay header
+//   - "mismatch"   — caller should return 409 (same key, different body)
+export async function lookupIdempotency(
+  apiKeyId: string,
+  idempotencyKey: string,
+  requestHash: string
+): Promise<IdempotencyLookup> {
+  const cached = await prisma.idempotencyKey.findUnique({
+    where: { apiKeyId_key: { apiKeyId, key: idempotencyKey } },
+  })
+
+  if (!cached) return { kind: "miss" }
+
+  // Treat stale rows as miss — opportunistically clean up so the unique
+  // constraint doesn't block the new insert.
+  if (Date.now() - cached.createdAt.getTime() >= IDEMPOTENCY_TTL_MS) {
+    await prisma.idempotencyKey.delete({ where: { id: cached.id } }).catch(() => {})
+    return { kind: "miss" }
+  }
+
+  if (cached.requestHash !== requestHash) return { kind: "mismatch" }
+
+  const response = new NextResponse(JSON.stringify(cached.responseBody), {
+    status: cached.responseStatus,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Idempotent-Replay": "true",
+    },
+  })
+  return { kind: "replay", response }
+}
+
+// Persist the response so a subsequent request with the same Idempotency-Key
+// gets the same answer. Stripe-style: only cache success — clients must be
+// free to retry on failure.
+export async function recordIdempotentResponse(opts: {
+  apiKeyId: string
+  idempotencyKey: string
+  requestHash: string
+  responseStatus: number
+  responseBody: unknown
+}): Promise<void> {
+  if (opts.responseStatus < 200 || opts.responseStatus >= 300) return
+
+  try {
+    await prisma.idempotencyKey.create({
+      data: {
+        apiKeyId: opts.apiKeyId,
+        key: opts.idempotencyKey,
+        requestHash: opts.requestHash,
+        responseStatus: opts.responseStatus,
+        responseBody: opts.responseBody as Prisma.InputJsonValue,
+      },
+    })
+  } catch (e) {
+    // Race: a concurrent request with the same (apiKeyId, key) inserted first.
+    // The first request "wins" — its response is canonical. The second created
+    // a duplicate downstream resource (the actual booking, in this case), which
+    // is the known-tradeoff of the simple insert-after pattern. Logged so it's
+    // observable; for Mira's sequential-retry use case it shouldn't happen.
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      console.warn(`Idempotency race on (${opts.apiKeyId}, ${opts.idempotencyKey}): another request stored first`)
+      return
+    }
+    throw e
+  }
+}


### PR DESCRIPTION
Closes #53.

## Summary
Adds Stripe-style idempotency to \`POST /api/v1/bookings\`. Bot retries can now safely re-send the same request without risking duplicate bookings.

\`\`\`http
POST /api/v1/bookings
Authorization: Bearer tc_live_...
Idempotency-Key: 5e0a2c1f-9b41-4d2e-89bd-7d1e9f4b3a0c
Content-Type: application/json

{ ...booking body... }
\`\`\`

- **Same key + same body within 24h** → original response replayed verbatim with \`X-Idempotent-Replay: true\` header
- **Same key + different body** → \`409\` with \`{ "error": "Idempotency-Key was previously used with a different request body" }\`
- **No key** → behaves exactly as before (no caching)
- **Failure responses (non-2xx) are NOT cached** → clients can safely retry on errors

## Migration
\`prisma/migrations/20260510000000_add_idempotency_key/\` — adds \`IdempotencyKey\` table with \`@@unique([apiKeyId, key])\`. Per-API-key scope so the same key value from two different bots can't collide.

## Implementation notes
- \`canonicalJson\` sorts object keys recursively so \`{a:1,b:2}\` and \`{b:2,a:1}\` hash identically
- Stale rows (>24h) treated as miss + opportunistically deleted on lookup; cron not strictly required (but helpful at scale)
- **Known limitation**: two truly concurrent requests with the same key can both reach \`createBooking()\` before either inserts. The simple insert-after pattern logs the P2002 race but the duplicate booking remains. For Mira's sequential-retry use case this is a non-issue; higher-concurrency callers would need an insert-then-execute pattern with a "pending" placeholder. Documented in code.

## Test plan
- [x] \`npx vitest run src/lib/api-keys/__tests__/idempotency src/__tests__/api/v1-bookings\` — 29/29 pass
  - 13 new on the helper (canonicalization, hashing, miss/replay/mismatch/stale, record success/failure-skip/race-handling)
  - 6 new on the route (no header path, with-header lookup, replay short-circuits createBooking, mismatch → 409, record after success, record with failure status forwarded)
- [x] Full unit suite — 206/206 pass
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual after deploy: \`curl -H "Idempotency-Key: test-1" ...\` twice in a row returns the same booking response, with \`X-Idempotent-Replay: true\` on the second
- [ ] Same key with different body returns 409
- [ ] No header → behaves like before

🤖 Generated with [Claude Code](https://claude.com/claude-code)