### PR TITLE
feat(webhooks): retry failed deliveries with exponential backoff

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -36,9 +36,25 @@ TinyCal sent the webhook (not the booking time).
 
 ### Retries
 
-Currently **none** — a delivery is attempted exactly once. Failed deliveries
-are logged on the server but not retried. Build receivers to be tolerant of
-duplicate or missed events; ack with a 2xx as soon as you've enqueued the work.
+**At-least-once delivery** with up to 3 attempts. A delivery is treated as
+failed if `fetch` throws (timeout / connection refused / DNS failure) or if
+the response status is not 2xx.
+
+| Attempt | Trigger                  |
+|---------|--------------------------|
+| 1       | Inline, immediately      |
+| 2       | 30 seconds after attempt 1 fails |
+| 3       | 5 minutes after attempt 2 fails  |
+
+After all 3 attempts fail, the delivery is marked permanently failed and the
+webhook row in **Dashboard → Webhooks** shows a "N failed deliveries in last
+24h" counter.
+
+**Receivers should be idempotent.** Because retries can fan out duplicate
+events (e.g., your service ack'd with 200 but the network dropped the
+response, then we retry), dedupe on the booking `uid` field. Ack with a 2xx
+as soon as you've enqueued the work — don't block the webhook on downstream
+processing.
 
 ## Verifying signatures
 

--- a/prisma/migrations/20260510010000_add_webhook_delivery/migration.sql
+++ b/prisma/migrations/20260510010000_add_webhook_delivery/migration.sql
@@ -1,0 +1,29 @@
+-- CreateEnum
+CREATE TYPE "DeliveryStatus" AS ENUM ('PENDING', 'SUCCEEDED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL,
+    "webhookId" TEXT NOT NULL,
+    "event" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "signature" TEXT NOT NULL,
+    "attempt" INTEGER NOT NULL DEFAULT 1,
+    "status" "DeliveryStatus" NOT NULL DEFAULT 'PENDING',
+    "responseCode" INTEGER,
+    "errorMessage" TEXT,
+    "nextAttemptAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_status_nextAttemptAt_idx" ON "WebhookDelivery"("status", "nextAttemptAt");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_webhookId_status_createdAt_idx" ON "WebhookDelivery"("webhookId", "status", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_webhookId_fkey" FOREIGN KEY ("webhookId") REFERENCES "Webhook"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -242,8 +242,39 @@ model Webhook {
   secret    String
   active    Boolean  @default(true)
 
-  createdAt DateTime @default(now())
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt  DateTime          @default(now())
+  user       User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deliveries WebhookDelivery[]
+}
+
+// One row per fanout attempt-set. Persisted so retries survive function cold
+// starts and so we can show delivery history on the dashboard. Status flows:
+// PENDING → SUCCEEDED, or PENDING → PENDING (with nextAttemptAt) → FAILED
+// after the third attempt also fails.
+model WebhookDelivery {
+  id            String         @id @default(cuid())
+  webhookId     String
+  event         String
+  payload       Json
+  signature     String
+  attempt       Int            @default(1)
+  status        DeliveryStatus @default(PENDING)
+  responseCode  Int?
+  errorMessage  String?
+  nextAttemptAt DateTime?
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+
+  webhook Webhook @relation(fields: [webhookId], references: [id], onDelete: Cascade)
+
+  @@index([status, nextAttemptAt])
+  @@index([webhookId, status, createdAt])
+}
+
+enum DeliveryStatus {
+  PENDING
+  SUCCEEDED
+  FAILED
 }
 
 // ─── Contacts ───

--- a/scripts/recover-failed-migration.ts
+++ b/scripts/recover-failed-migration.ts
@@ -21,9 +21,9 @@ async function main() {
   const prisma = new PrismaClient()
   try {
     // Safety check — refuse to drop a table that has rows
-    const rowCount: Array<{ count: bigint }> = await prisma.$queryRawUnsafe(
+    const rowCount = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
       `SELECT COUNT(*)::bigint AS count FROM "AvailabilitySchedule"`
-    ).catch(() => [{ count: BigInt(-1) }])
+    ).catch(() => [{ count: BigInt(-1) }] as Array<{ count: bigint }>)
 
     if (rowCount[0].count === BigInt(-1)) {
       console.log("AvailabilitySchedule does not exist — nothing to drop. Proceeding to mark rolled-back.")

--- a/src/__tests__/api/cron-webhook-retries.test.ts
+++ b/src/__tests__/api/cron-webhook-retries.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const mockDeliveryFindMany = vi.fn()
+const mockDeliveryUpdate = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    webhookDelivery: {
+      findMany: (...args: any[]) => mockDeliveryFindMany(...args),
+      update: (...args: any[]) => mockDeliveryUpdate(...args),
+    },
+  },
+}))
+
+import { GET } from "@/app/api/cron/webhook-retries/route"
+
+const originalFetch = global.fetch
+const SECRET = "test-cron-secret"
+
+function makeReq(token = SECRET): Request {
+  return new Request("http://localhost/api/cron/webhook-retries", {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+describe("GET /api/cron/webhook-retries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = SECRET
+    global.fetch = vi.fn()
+    mockDeliveryUpdate.mockResolvedValue({})
+  })
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it("returns 401 without the cron secret", async () => {
+    const res = await GET(new Request("http://x/api/cron/webhook-retries"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 401 with the wrong cron secret", async () => {
+    const res = await GET(makeReq("wrong"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 200 with zeros when nothing is due", async () => {
+    mockDeliveryFindMany.mockResolvedValueOnce([])
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ processed: 0, succeeded: 0, stillRetrying: 0, failed: 0 })
+  })
+
+  it("retries a due delivery and marks it SUCCEEDED on 2xx", async () => {
+    mockDeliveryFindMany.mockResolvedValueOnce([{
+      id: "d-1", attempt: 1, signature: "sig", payload: { event: "booking.created" },
+      webhook: { url: "https://hook/1" },
+    }])
+    ;(global.fetch as any).mockResolvedValue({ ok: true, status: 200 })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body).toEqual({ processed: 1, succeeded: 1, stillRetrying: 0, failed: 0 })
+    expect(mockDeliveryUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "d-1" },
+        data: expect.objectContaining({ status: "SUCCEEDED", attempt: 2 }),
+      })
+    )
+  })
+
+  it("on second-attempt failure (attempt was 1, now 2): keeps PENDING with new backoff", async () => {
+    mockDeliveryFindMany.mockResolvedValueOnce([{
+      id: "d-1", attempt: 1, signature: "sig", payload: {}, webhook: { url: "https://hook" },
+    }])
+    ;(global.fetch as any).mockResolvedValue({ ok: false, status: 503 })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body.stillRetrying).toBe(1)
+    expect(body.failed).toBe(0)
+  })
+
+  it("on the final attempt failing: marks FAILED", async () => {
+    // attempt was 2, retried = 3 = MAX
+    mockDeliveryFindMany.mockResolvedValueOnce([{
+      id: "d-1", attempt: 2, signature: "sig", payload: {}, webhook: { url: "https://hook" },
+    }])
+    ;(global.fetch as any).mockResolvedValue({ ok: false, status: 503 })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body.failed).toBe(1)
+    expect(body.stillRetrying).toBe(0)
+    expect(mockDeliveryUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "FAILED" }),
+      })
+    )
+  })
+
+  it("only picks up rows where status=PENDING and nextAttemptAt <= now", async () => {
+    mockDeliveryFindMany.mockResolvedValueOnce([])
+    await GET(makeReq())
+    expect(mockDeliveryFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: "PENDING",
+          nextAttemptAt: { lte: expect.any(Date) },
+        }),
+      })
+    )
+  })
+})

--- a/src/app/api/cron/webhook-retries/route.ts
+++ b/src/app/api/cron/webhook-retries/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server"
+import prisma from "@/lib/prisma"
+import { attemptHttpDelivery, persistAttemptResult } from "@/lib/webhooks"
+
+// Cron-driven retry of failed webhook deliveries.
+//
+// Pickup criteria: status=PENDING AND nextAttemptAt <= now.
+// Every PENDING delivery with a past nextAttemptAt gets one more attempt;
+// persistAttemptResult() handles the state transition (success → SUCCEEDED,
+// failure → either next backoff or FAILED if MAX_DELIVERY_ATTEMPTS reached).
+//
+// Recommended schedule: every 1–2 minutes. 30s is the smallest backoff so
+// 1min granularity is fine.
+export async function GET(req: Request) {
+  const authHeader = req.headers.get("Authorization")
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const now = new Date()
+  const due = await prisma.webhookDelivery.findMany({
+    where: {
+      status: "PENDING",
+      nextAttemptAt: { lte: now },
+    },
+    include: { webhook: true },
+    take: 100,
+  })
+
+  let succeeded = 0
+  let stillRetrying = 0
+  let failed = 0
+
+  for (const delivery of due) {
+    const payload = JSON.stringify(delivery.payload)
+    const result = await attemptHttpDelivery({
+      url: delivery.webhook.url,
+      payload,
+      signature: delivery.signature,
+    })
+    const newAttempt = delivery.attempt + 1
+    await persistAttemptResult(delivery.id, newAttempt, result)
+
+    if (result.ok) succeeded++
+    else if (newAttempt >= 3) failed++
+    else stillRetrying++
+  }
+
+  return NextResponse.json({
+    processed: due.length,
+    succeeded,
+    stillRetrying,
+    failed,
+  })
+}

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -10,7 +10,27 @@ export async function GET() {
   const webhooks = await prisma.webhook.findMany({
     where: { userId: user.id },
   })
-  return NextResponse.json(webhooks)
+
+  // Surface a 24h failure counter per webhook so the dashboard can flag
+  // delivery problems without a follow-up request.
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000)
+  const failureCounts = await prisma.webhookDelivery.groupBy({
+    by: ["webhookId"],
+    where: {
+      webhookId: { in: webhooks.map(w => w.id) },
+      status: "FAILED",
+      createdAt: { gte: since },
+    },
+    _count: { _all: true },
+  })
+  const countByWebhook = new Map(failureCounts.map(c => [c.webhookId, c._count._all]))
+
+  return NextResponse.json(
+    webhooks.map(w => ({
+      ...w,
+      failedDeliveryCount24h: countByWebhook.get(w.id) ?? 0,
+    }))
+  )
 }
 
 export async function POST(req: Request) {

--- a/src/app/dashboard/webhooks/page.tsx
+++ b/src/app/dashboard/webhooks/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { Plus, Trash2, Copy } from "lucide-react"
+import { Plus, Trash2, Copy, AlertTriangle } from "lucide-react"
 
 export default function WebhooksPage() {
   const [webhooks, setWebhooks] = useState<any[]>([])
@@ -67,6 +67,12 @@ export default function WebhooksPage() {
                   <Copy className="w-3 h-3" />
                 </button>
               </div>
+              {wh.failedDeliveryCount24h > 0 && (
+                <div className="flex items-center gap-1 mt-1 text-xs text-amber-700">
+                  <AlertTriangle className="w-3 h-3" />
+                  {wh.failedDeliveryCount24h} failed {wh.failedDeliveryCount24h === 1 ? "delivery" : "deliveries"} in last 24h
+                </div>
+              )}
             </div>
             <button onClick={() => handleDelete(wh.id)} className="p-2 hover:bg-red-50 rounded-lg">
               <Trash2 className="w-4 h-4 text-red-500" />

--- a/src/lib/__tests__/webhooks.test.ts
+++ b/src/lib/__tests__/webhooks.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { signPayload, attemptHttpDelivery, nextAttemptDelay, persistAttemptResult, triggerWebhooks, MAX_DELIVERY_ATTEMPTS } from "../webhooks"
+
+const mockWebhookFindMany = vi.fn()
+const mockDeliveryCreate = vi.fn()
+const mockDeliveryUpdate = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    webhook: {
+      findMany: (...args: any[]) => mockWebhookFindMany(...args),
+    },
+    webhookDelivery: {
+      create: (...args: any[]) => mockDeliveryCreate(...args),
+      update: (...args: any[]) => mockDeliveryUpdate(...args),
+    },
+  },
+}))
+
+const originalFetch = global.fetch
+
+describe("signPayload", () => {
+  it("produces a deterministic 64-char hex digest", () => {
+    const sig1 = signPayload("secret", "{}")
+    const sig2 = signPayload("secret", "{}")
+    expect(sig1).toBe(sig2)
+    expect(sig1).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it("changes when secret or body changes", () => {
+    expect(signPayload("a", "x")).not.toBe(signPayload("b", "x"))
+    expect(signPayload("a", "x")).not.toBe(signPayload("a", "y"))
+  })
+})
+
+describe("attemptHttpDelivery", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn()
+  })
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it("returns ok=true on 2xx response", async () => {
+    ;(global.fetch as any).mockResolvedValue({ ok: true, status: 200 })
+    const result = await attemptHttpDelivery({ url: "https://x", payload: "{}", signature: "sig" })
+    expect(result).toEqual({ ok: true, responseCode: 200 })
+  })
+
+  it("returns ok=false on non-2xx with the response code", async () => {
+    ;(global.fetch as any).mockResolvedValue({ ok: false, status: 503 })
+    const result = await attemptHttpDelivery({ url: "https://x", payload: "{}", signature: "sig" })
+    expect(result).toEqual({ ok: false, responseCode: 503, errorMessage: "HTTP 503" })
+  })
+
+  it("returns ok=false on network error (caught, never thrown)", async () => {
+    ;(global.fetch as any).mockRejectedValue(new Error("ECONNREFUSED"))
+    const result = await attemptHttpDelivery({ url: "https://x", payload: "{}", signature: "sig" })
+    expect(result.ok).toBe(false)
+    expect(result.errorMessage).toBe("ECONNREFUSED")
+  })
+
+  it("sends X-Webhook-Signature header", async () => {
+    ;(global.fetch as any).mockResolvedValue({ ok: true, status: 200 })
+    await attemptHttpDelivery({ url: "https://x", payload: "{}", signature: "deadbeef" })
+    const call = (global.fetch as any).mock.calls[0]
+    expect(call[1].headers["X-Webhook-Signature"]).toBe("deadbeef")
+  })
+})
+
+describe("nextAttemptDelay (backoff schedule)", () => {
+  it("returns 30s after attempt 1", () => {
+    expect(nextAttemptDelay(1)).toBe(30 * 1000)
+  })
+
+  it("returns 5min after attempt 2", () => {
+    expect(nextAttemptDelay(2)).toBe(5 * 60 * 1000)
+  })
+
+  it("returns null after the final attempt (no more retries)", () => {
+    expect(nextAttemptDelay(MAX_DELIVERY_ATTEMPTS)).toBeNull()
+  })
+})
+
+describe("persistAttemptResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeliveryUpdate.mockResolvedValue({})
+  })
+
+  it("marks SUCCEEDED on ok=true", async () => {
+    await persistAttemptResult("d-1", 1, { ok: true, responseCode: 200 })
+    expect(mockDeliveryUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "d-1" },
+        data: expect.objectContaining({
+          status: "SUCCEEDED",
+          attempt: 1,
+          responseCode: 200,
+          nextAttemptAt: null,
+        }),
+      })
+    )
+  })
+
+  it("schedules next attempt on first failure (status stays PENDING)", async () => {
+    const before = Date.now()
+    await persistAttemptResult("d-1", 1, { ok: false, responseCode: 503 })
+    const call = mockDeliveryUpdate.mock.calls[0][0]
+    expect(call.data.status).toBe("PENDING")
+    expect(call.data.responseCode).toBe(503)
+    const nextMs = call.data.nextAttemptAt.getTime() - before
+    expect(nextMs).toBeGreaterThanOrEqual(30 * 1000 - 50)
+    expect(nextMs).toBeLessThanOrEqual(30 * 1000 + 1000)
+  })
+
+  it("schedules longer delay on second failure", async () => {
+    const before = Date.now()
+    await persistAttemptResult("d-1", 2, { ok: false, errorMessage: "timeout" })
+    const call = mockDeliveryUpdate.mock.calls[0][0]
+    expect(call.data.status).toBe("PENDING")
+    const nextMs = call.data.nextAttemptAt.getTime() - before
+    expect(nextMs).toBeGreaterThanOrEqual(5 * 60 * 1000 - 50)
+  })
+
+  it("marks FAILED after the final attempt also fails", async () => {
+    await persistAttemptResult("d-1", MAX_DELIVERY_ATTEMPTS, { ok: false, errorMessage: "still down" })
+    expect(mockDeliveryUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "FAILED",
+          nextAttemptAt: null,
+          errorMessage: "still down",
+        }),
+      })
+    )
+  })
+})
+
+describe("triggerWebhooks (fanout)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    global.fetch = vi.fn()
+    mockDeliveryCreate.mockImplementation(async ({ data }) => ({ id: "d-new", ...data }))
+    mockDeliveryUpdate.mockResolvedValue({})
+  })
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it("does nothing when no webhooks match", async () => {
+    mockWebhookFindMany.mockResolvedValueOnce([])
+    await triggerWebhooks("user-1", "booking.created", {})
+    expect(mockDeliveryCreate).not.toHaveBeenCalled()
+  })
+
+  it("creates a Delivery row + attempts immediately + marks SUCCEEDED on 2xx", async () => {
+    mockWebhookFindMany.mockResolvedValueOnce([
+      { id: "wh-1", url: "https://hook/1", secret: "secret-1" },
+    ])
+    ;(global.fetch as any).mockResolvedValue({ ok: true, status: 200 })
+
+    await triggerWebhooks("user-1", "booking.created", { hello: "world" })
+
+    expect(mockDeliveryCreate).toHaveBeenCalledTimes(1)
+    expect(mockDeliveryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ webhookId: "wh-1", attempt: 1, status: "PENDING" }),
+      })
+    )
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(mockDeliveryUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "SUCCEEDED" }),
+      })
+    )
+  })
+
+  it("on first failure: row stays PENDING with nextAttemptAt set", async () => {
+    mockWebhookFindMany.mockResolvedValueOnce([
+      { id: "wh-1", url: "https://hook/1", secret: "secret-1" },
+    ])
+    ;(global.fetch as any).mockResolvedValue({ ok: false, status: 503 })
+
+    await triggerWebhooks("user-1", "booking.created", {})
+
+    const updateCall = mockDeliveryUpdate.mock.calls[0][0]
+    expect(updateCall.data.status).toBe("PENDING")
+    expect(updateCall.data.nextAttemptAt).toBeInstanceOf(Date)
+  })
+
+  it("fans out to multiple webhooks subscribed to the event", async () => {
+    mockWebhookFindMany.mockResolvedValueOnce([
+      { id: "wh-1", url: "https://hook/1", secret: "s1" },
+      { id: "wh-2", url: "https://hook/2", secret: "s2" },
+    ])
+    ;(global.fetch as any).mockResolvedValue({ ok: true, status: 200 })
+
+    await triggerWebhooks("user-1", "booking.created", {})
+    expect(mockDeliveryCreate).toHaveBeenCalledTimes(2)
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -1,29 +1,125 @@
 import crypto from "crypto"
+import { Prisma } from "@prisma/client"
 import prisma from "./prisma"
 
-export async function triggerWebhooks(userId: string, event: string, data: any) {
+// Backoff schedule. Index = attempt number that just *failed* (1-based).
+// After attempt 1 fails, the next attempt is in 30s. After attempt 2, +5min.
+// After attempt 3 fails, we give up.
+const RETRY_DELAYS_MS = [
+  30 * 1000,        // attempt 1 → 2 (30s)
+  5 * 60 * 1000,    // attempt 2 → 3 (5min)
+] as const
+
+export const MAX_DELIVERY_ATTEMPTS = RETRY_DELAYS_MS.length + 1
+
+export function signPayload(secret: string, body: string): string {
+  return crypto.createHmac("sha256", secret).update(body).digest("hex")
+}
+
+// Try once to POST the payload to the webhook URL. Returns the result for the
+// caller to persist. Does not throw — network errors, timeouts, and non-2xx
+// all surface as `ok: false`.
+export async function attemptHttpDelivery(opts: {
+  url: string
+  payload: string
+  signature: string
+}): Promise<{ ok: boolean; responseCode?: number; errorMessage?: string }> {
+  try {
+    const res = await fetch(opts.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": opts.signature,
+      },
+      body: opts.payload,
+    })
+    if (res.ok) return { ok: true, responseCode: res.status }
+    return { ok: false, responseCode: res.status, errorMessage: `HTTP ${res.status}` }
+  } catch (e) {
+    return { ok: false, errorMessage: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+// Compute the next-attempt timestamp for a delivery that just failed at the
+// given attempt number. Returns null if no more retries (the caller marks
+// the row FAILED).
+export function nextAttemptDelay(failedAttempt: number): number | null {
+  return RETRY_DELAYS_MS[failedAttempt - 1] ?? null
+}
+
+// Public entrypoint: fans out an event to all matching webhooks. Each webhook
+// gets its own WebhookDelivery row that tracks attempts + status. The first
+// attempt happens inline; failures are picked up by the cron at
+// /api/cron/webhook-retries.
+export async function triggerWebhooks(userId: string, event: string, data: unknown) {
   const webhooks = await prisma.webhook.findMany({
     where: { userId, active: true, events: { has: event } },
   })
 
   for (const webhook of webhooks) {
     const payload = JSON.stringify({ event, data, timestamp: new Date().toISOString() })
-    const signature = crypto
-      .createHmac("sha256", webhook.secret)
-      .update(payload)
-      .digest("hex")
+    const signature = signPayload(webhook.secret, payload)
 
-    try {
-      await fetch(webhook.url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Signature": signature,
-        },
-        body: payload,
-      })
-    } catch (error) {
-      console.error(`Webhook ${webhook.id} failed:`, error)
-    }
+    const delivery = await prisma.webhookDelivery.create({
+      data: {
+        webhookId: webhook.id,
+        event,
+        payload: JSON.parse(payload) as Prisma.InputJsonValue,
+        signature,
+        attempt: 1,
+        status: "PENDING",
+      },
+    })
+
+    const result = await attemptHttpDelivery({ url: webhook.url, payload, signature })
+    await persistAttemptResult(delivery.id, 1, result)
   }
+}
+
+// Updates a delivery row with the result of the most recent attempt.
+// Exported for the cron retry route.
+export async function persistAttemptResult(
+  deliveryId: string,
+  attempt: number,
+  result: { ok: boolean; responseCode?: number; errorMessage?: string }
+): Promise<void> {
+  if (result.ok) {
+    await prisma.webhookDelivery.update({
+      where: { id: deliveryId },
+      data: {
+        status: "SUCCEEDED",
+        attempt,
+        responseCode: result.responseCode,
+        errorMessage: null,
+        nextAttemptAt: null,
+      },
+    })
+    return
+  }
+
+  const delayMs = nextAttemptDelay(attempt)
+  if (delayMs === null) {
+    await prisma.webhookDelivery.update({
+      where: { id: deliveryId },
+      data: {
+        status: "FAILED",
+        attempt,
+        responseCode: result.responseCode ?? null,
+        errorMessage: result.errorMessage ?? null,
+        nextAttemptAt: null,
+      },
+    })
+    return
+  }
+
+  await prisma.webhookDelivery.update({
+    where: { id: deliveryId },
+    data: {
+      status: "PENDING",
+      attempt,
+      responseCode: result.responseCode ?? null,
+      errorMessage: result.errorMessage ?? null,
+      nextAttemptAt: new Date(Date.now() + delayMs),
+    },
+  })
 }


### PR DESCRIPTION
Closes #54.

## Summary
At-least-once webhook delivery, persisted in a new \`WebhookDelivery\` table so retries survive function cold starts.

| Attempt | Trigger |
|---------|---------|
| 1 | Inline, on \`triggerWebhooks(...)\` call |
| 2 | 30s after attempt 1 fails |
| 3 | 5min after attempt 2 fails |

After all 3 attempts fail, the row is marked \`FAILED\` and \`/dashboard/webhooks\` shows a "N failed deliveries in last 24h" counter on the affected webhook.

## Why
Per #54: previously \`src/lib/webhooks.ts\` attempted each delivery exactly once and just \`console.error\`d on failure. A 5-second receiver outage would silently drop a \`booking.created\` event — for the Mira concierge use case (#33), the WhatsApp confirmation never sends.

## Migration
\`prisma/migrations/20260510010000_add_webhook_delivery/migration.sql\` — adds \`WebhookDelivery\` table + \`DeliveryStatus\` enum. Cascade-deleted with the parent webhook. Two indexes: \`(status, nextAttemptAt)\` for the cron pickup query, \`(webhookId, status, createdAt)\` for the dashboard counter.

## Cron setup needed after merge
A new route lives at \`/api/cron/webhook-retries\`. Same auth pattern as the existing \`/api/cron/reminders\` — \`Authorization: Bearer ${process.env.CRON_SECRET}\`. **It needs to be invoked on a schedule** (Vercel Cron or external scheduler) — recommended every 1–2 minutes since the smallest backoff is 30s. Currently no \`vercel.json\` so this isn't wired up automatically; whatever's invoking \`/api/cron/reminders\` today should be extended.

## Test plan
- [x] 17 new unit tests on \`src/lib/webhooks\` (signature, attempt, backoff schedule, state transitions, fanout)
- [x] 7 new tests on the cron route (auth, empty queue, success/retry/final-failure paths)
- [x] Full unit suite — 211/211 pass
- [x] \`npx tsc --noEmit\` clean
- [ ] **Manual after deploy**: configure a webhook to point at httpbin.org/status/503 → trigger a booking → verify a row appears in \`WebhookDelivery\` with status=PENDING after attempt 1 fails
- [ ] Schedule the cron + wait → verify attempt count increments, and after attempt 3 the row goes FAILED
- [ ] Refresh \`/dashboard/webhooks\` → see the failure counter
- [ ] Point the same webhook back at a working URL → trigger another booking → verify the new delivery succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)