### PR TITLE
fix(build): only run prisma migrate deploy on production deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && prisma migrate deploy && next build",
+    "build": "prisma generate && (if [ \"$VERCEL_ENV\" = \"production\" ]; then prisma migrate deploy; fi) && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",

--- a/scripts/diagnose-failed-migration.ts
+++ b/scripts/diagnose-failed-migration.ts
@@ -30,10 +30,11 @@ async function main() {
       migration_name: string
       started_at: Date
       finished_at: Date | null
+      rolled_back_at: Date | null
       applied_steps_count: number
       logs: string | null
     }> = await prisma.$queryRawUnsafe(
-      `SELECT migration_name, started_at, finished_at, applied_steps_count, logs
+      `SELECT migration_name, started_at, finished_at, rolled_back_at, applied_steps_count, logs
        FROM _prisma_migrations
        WHERE migration_name = '20260408000000_add_availability_schedules'`
     )
@@ -49,11 +50,18 @@ async function main() {
       console.log("  (no row found — migration was never recorded as started)")
     } else {
       const r = migrationRow[0]
+      const state = r.rolled_back_at
+        ? "ROLLED BACK (will be re-applied on next migrate deploy)"
+        : r.finished_at
+          ? "APPLIED"
+          : "PARTIAL (blocking)"
       console.log("  migration_name:        " + r.migration_name)
       console.log("  started_at:            " + r.started_at?.toISOString())
-      console.log("  finished_at:           " + (r.finished_at?.toISOString() ?? "NULL (partial)"))
+      console.log("  finished_at:           " + (r.finished_at?.toISOString() ?? "NULL"))
+      console.log("  rolled_back_at:        " + (r.rolled_back_at?.toISOString() ?? "NULL"))
       console.log("  applied_steps_count:   " + r.applied_steps_count)
-      if (r.logs) console.log("  logs:\n" + r.logs.split("\n").map(l => "    " + l).join("\n"))
+      console.log("  state:                 " + state)
+      if (r.logs && !r.rolled_back_at) console.log("  logs:\n" + r.logs.split("\n").map(l => "    " + l).join("\n"))
     }
   } finally {
     await prisma.$disconnect()

--- a/scripts/diagnose-failed-migration.ts
+++ b/scripts/diagnose-failed-migration.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-console */
+// One-off diagnostic for the P3009 failed-migration block on prod (silent-pond).
+// Reports: (a) which of the AvailabilitySchedule tables exist, and (b) the
+// _prisma_migrations row for the blocked migration. Use the output to decide
+// between `prisma migrate resolve --applied` (forward) and --rolled-back
+// (backward, if schema is clean).
+import { PrismaClient } from "@prisma/client"
+
+async function main() {
+  const prisma = new PrismaClient()
+  try {
+    const tables: Array<{ table_name: string }> = await prisma.$queryRawUnsafe(
+      `SELECT table_name
+       FROM information_schema.tables
+       WHERE table_schema = 'public'
+         AND table_name IN ('AvailabilitySchedule', 'AvailabilityRule')`
+    )
+
+    const newColumns: Array<{ table_name: string; column_name: string }> = await prisma.$queryRawUnsafe(
+      `SELECT table_name, column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND (
+           (table_name = 'EventType' AND column_name = 'availabilityScheduleId') OR
+           (table_name = 'User' AND column_name = 'defaultAvailabilityScheduleId')
+         )`
+    )
+
+    const migrationRow: Array<{
+      migration_name: string
+      started_at: Date
+      finished_at: Date | null
+      applied_steps_count: number
+      logs: string | null
+    }> = await prisma.$queryRawUnsafe(
+      `SELECT migration_name, started_at, finished_at, applied_steps_count, logs
+       FROM _prisma_migrations
+       WHERE migration_name = '20260408000000_add_availability_schedules'`
+    )
+
+    console.log("Tables present in public schema:")
+    console.log(tables.length === 0 ? "  (none)" : tables.map(t => "  " + t.table_name).join("\n"))
+    console.log("")
+    console.log("New columns added by the migration:")
+    console.log(newColumns.length === 0 ? "  (none)" : newColumns.map(c => "  " + c.table_name + "." + c.column_name).join("\n"))
+    console.log("")
+    console.log("_prisma_migrations row for the failed migration:")
+    if (migrationRow.length === 0) {
+      console.log("  (no row found — migration was never recorded as started)")
+    } else {
+      const r = migrationRow[0]
+      console.log("  migration_name:        " + r.migration_name)
+      console.log("  started_at:            " + r.started_at?.toISOString())
+      console.log("  finished_at:           " + (r.finished_at?.toISOString() ?? "NULL (partial)"))
+      console.log("  applied_steps_count:   " + r.applied_steps_count)
+      if (r.logs) console.log("  logs:\n" + r.logs.split("\n").map(l => "    " + l).join("\n"))
+    }
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/recover-failed-migration.ts
+++ b/scripts/recover-failed-migration.ts
@@ -1,0 +1,72 @@
+/* eslint-disable no-console */
+// Recovery for the partial state of 20260408000000_add_availability_schedules.
+//
+// Before running, verify the diagnostic output matches what we expect:
+//   - AvailabilitySchedule table exists (empty)
+//   - AvailabilityRule table does NOT exist
+//   - EventType.availabilityScheduleId column exists (all NULL)
+//   - User.defaultAvailabilityScheduleId column does NOT exist
+//
+// This script:
+//   1. Confirms AvailabilitySchedule is empty (refuses to proceed otherwise)
+//   2. Drops the partially-applied table + column with IF EXISTS / CASCADE
+//   3. Tells you to run `prisma migrate resolve --rolled-back ...` after
+//
+// Run:  npx tsx scripts/recover-failed-migration.ts
+import { PrismaClient } from "@prisma/client"
+
+const MIGRATION_NAME = "20260408000000_add_availability_schedules"
+
+async function main() {
+  const prisma = new PrismaClient()
+  try {
+    // Safety check — refuse to drop a table that has rows
+    const rowCount: Array<{ count: bigint }> = await prisma.$queryRawUnsafe(
+      `SELECT COUNT(*)::bigint AS count FROM "AvailabilitySchedule"`
+    ).catch(() => [{ count: BigInt(-1) }])
+
+    if (rowCount[0].count === BigInt(-1)) {
+      console.log("AvailabilitySchedule does not exist — nothing to drop. Proceeding to mark rolled-back.")
+    } else if (rowCount[0].count > BigInt(0)) {
+      console.error(`REFUSING TO PROCEED: AvailabilitySchedule has ${rowCount[0].count} rows. Manual review required.`)
+      process.exit(1)
+    } else {
+      console.log("AvailabilitySchedule is empty — safe to drop.")
+    }
+
+    console.log("\n→ Dropping partially-applied schema objects...")
+    await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS "AvailabilityRule" CASCADE`)
+    await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS "AvailabilitySchedule" CASCADE`)
+    await prisma.$executeRawUnsafe(`ALTER TABLE "EventType" DROP COLUMN IF EXISTS "availabilityScheduleId"`)
+    await prisma.$executeRawUnsafe(`ALTER TABLE "User" DROP COLUMN IF EXISTS "defaultAvailabilityScheduleId"`)
+    console.log("  Done.")
+
+    console.log("\n→ Verifying clean state...")
+    const tables: Array<{ table_name: string }> = await prisma.$queryRawUnsafe(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name IN ('AvailabilitySchedule','AvailabilityRule')`
+    )
+    const columns: Array<{ table_name: string; column_name: string }> = await prisma.$queryRawUnsafe(
+      `SELECT table_name, column_name FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND ((table_name='EventType' AND column_name='availabilityScheduleId')
+              OR (table_name='User' AND column_name='defaultAvailabilityScheduleId'))`
+    )
+    if (tables.length > 0 || columns.length > 0) {
+      console.error("  ERROR: residual schema objects remain:", tables, columns)
+      process.exit(1)
+    }
+    console.log("  Clean.")
+
+    console.log("\n→ Next step (run this yourself, NOT this script):")
+    console.log(`  npx prisma migrate resolve --rolled-back ${MIGRATION_NAME}`)
+    console.log("\nThen re-run the diagnose script to confirm _prisma_migrations row is gone.")
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Incident this fixes

PR #32's preview build attempted to apply migration \`20260408000000_add_availability_schedules\` against **prod** (silent-pond — the only DATABASE_URL scope in Vercel is shared by previews and prod). The migration partially failed mid-way, leaving prod's \`_prisma_migrations\` table with a P3009 "failed migration" row. Once that row exists, **Prisma refuses to apply ANY further migrations** to prod from any branch.

Diagnostic confirms:
- ✅ \`AvailabilitySchedule\` table exists (empty)
- ❌ \`AvailabilityRule\` table missing
- ✅ \`EventType.availabilityScheduleId\` column exists (all NULL)
- ❌ \`User.defaultAvailabilityScheduleId\` column missing
- Migration row: \`finished_at = NULL\`, \`applied_steps_count = 0\`

This blocks main, PR #57, #58, #59, #60, #61, #62 — every open PR.

## Fix

Gate \`prisma migrate deploy\` on \`$VERCEL_ENV == "production"\`. Preview builds now run \`prisma generate && next build\` (no migrate). Production builds keep the full chain.

\`\`\`json
"build": "prisma generate && (if [ \"$VERCEL_ENV\" = \"production\" ]; then prisma migrate deploy; fi) && next build"
\`\`\`

Tested shell semantics with all 4 cases:
| Scenario | Behavior |
|----------|----------|
| Preview (\`VERCEL_ENV\` = preview / unset) | generate + next build (skip migrate) ✓ |
| Production (\`VERCEL_ENV=production\`, all OK) | generate + migrate + next build ✓ |
| Production with migrate failure | build skipped, non-zero exit ✓ |

## Recovery for the existing failed migration

This PR also ships two scripts in \`scripts/\`:
- \`diagnose-failed-migration.ts\` — prints current schema state + the migration row
- \`recover-failed-migration.ts\` — drops the partial table/column with safety checks (refuses if \`AvailabilitySchedule\` has rows)

Recovery sequence (run yourself, after merge):
\`\`\`
npx tsx scripts/diagnose-failed-migration.ts
npx tsx scripts/recover-failed-migration.ts
npx prisma migrate resolve --rolled-back 20260408000000_add_availability_schedules
\`\`\`

After that, the next prod deploy from main will go through cleanly.

## Out of scope (follow-ups)

This is the immediate gate. Proper long-term fix:
1. **Separate Neon branch DB for previews** so schema changes can be tested in isolation before merge. Today's fix means previews effectively can't test schema-changing PRs at all (they'll just compile against the current prod schema).
2. **PR #32 itself still needs work** — beyond the migration block, it conflicts with PR #47 and PR #59 in \`src/app/dashboard/event-types/[id]/page.tsx\` and \`src/app/api/event-types/[id]/route.ts\`.

Will file both as separate issues if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)