### PR TITLE
chore(build): remove redundant prisma migrate from Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && (if [ \"$VERCEL_ENV\" = \"production\" ]; then prisma migrate deploy; fi) && next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",


### PR DESCRIPTION
## TL;DR
The Vercel build's \`prisma migrate deploy\` was redundant from the start. \`.github/workflows/deploy-migrations.yml\` was already running migrations on every \`main\` push that touches \`prisma/**\`. Reverting the build script back to plain \`prisma generate && next build\`.

## Background
- **Pre-#45**: only the GH Action ran migrations
- **#45 (mine)**: added \`prisma migrate deploy\` to the Vercel build script. I didn't know the GH Action existed
- **PR #32 incident**: the duplicate migrate-on-build path caused a preview to apply a migration to prod, which partially failed and bricked further migrations
- **#63 (mine)**: gated the Vercel-build migrate to prod-only. Stopped the preview problem but left the duplicate on prod
- **This PR**: removes the duplicate entirely. GH Action is the single source of migration truth.

## Evidence the GH Action works
\`\`\`
$ gh run view 25613732255 --log | grep -E "Applying|applied"
2026-05-09T22:46:13.7467Z  Applying migration \`20260509000000_add_api_keys\`
2026-05-09T22:46:14.3196Z  The following migration(s) have been applied
2026-05-09T22:46:14.3199Z  All migrations have been successfully applied.
\`\`\`

That ran 28 seconds after PR #40 was merged. The Vercel-build migrate would have been a no-op by the time it executed.

## Trade-off
If the GH Action fails or is disabled, prod migrations stop until someone re-runs it. But that's a clean failure mode — much better than the alternative (two pipelines, one of which can run on previews, with no coordination). The GH Action's \`workflow_dispatch\` trigger lets ops re-run manually if needed.

## Test plan
- [x] No code changes — just removes the build-step migrate call
- [ ] After merge: next push to main with no prisma changes deploys cleanly via Vercel
- [ ] Next PR with prisma changes (e.g. one of #61, #62) merges → GH Action triggers and applies the migration → Vercel build then runs without trying

## Note for #57
The Deployment section in PR #57's README rewrite says \`prisma migrate deploy\` runs in the Vercel build. I'll update that section before #57 merges (or in a follow-up) so the README matches reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)