### PR TITLE
docs(privacy): drop stale AWS Amplify reference

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -92,7 +92,7 @@ export default function PrivacyPolicy() {
         <p>
           Your data is stored in secure, encrypted databases hosted on Neon (PostgreSQL). OAuth tokens
           are stored encrypted. We use HTTPS for all data transmission. The Service is hosted on
-          AWS Amplify / Vercel with industry-standard security measures.
+          Vercel with industry-standard security measures.
         </p>
 
         <h2>6. Data Retention</h2>


### PR DESCRIPTION
One-line fix: privacy policy's Data Storage section listed "AWS Amplify / Vercel" as hosting providers. After #56/#57 confirmed Vercel is the only host, this should match.

Worth getting right before submitting for Google OAuth verification (in flight as part of #50's Cloud Console branding setup) — reviewers cross-check policy text against the actual stack you describe in your verification submission.

\`\`\`diff
- The Service is hosted on AWS Amplify / Vercel with industry-standard security measures.
+ The Service is hosted on Vercel with industry-standard security measures.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)