### PR TITLE
feat(calendar): reconcile cron for out-of-band Google edits

### DIFF
--- a/src/app/api/cron/calendar-sync/route.ts
+++ b/src/app/api/cron/calendar-sync/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from "next/server"
+import { addDays, addHours, format } from "date-fns"
+import { toZonedTime } from "date-fns-tz"
+import { Prisma } from "@prisma/client"
+import prisma from "@/lib/prisma"
+import { getGoogleCalendarEvent } from "@/lib/calendar/google"
+import { sendEmail, bookingCancelledEmail } from "@/lib/email"
+import { triggerWebhooks } from "@/lib/webhooks"
+import { buildBookingPayload } from "@/lib/webhooks/booking-payload"
+
+const reconcileInclude = {
+  eventType: { include: { user: true } },
+} satisfies Prisma.BookingInclude
+
+type ReconcileBooking = Prisma.BookingGetPayload<{ include: typeof reconcileInclude }>
+
+// Reconcile TinyCal bookings against the host's Google Calendar. Detects events
+// the host moved or deleted directly in their calendar (outside TinyCal) and
+// updates the matching Booking row.
+//
+// Scope: Google Meet bookings only — those are the ones whose meetingId is
+// guaranteed to be a Google calendar event id. Outlook event ids aren't stored
+// on Booking today, so Outlook reconcile is a separate task.
+//
+// 404/410 from Google is treated as ambiguous (could be a stale connection on
+// a pre-primary-fix booking) and is logged + skipped rather than auto-cancelled.
+// Only an explicit status="cancelled" triggers cancellation.
+//
+// Recommended schedule: every 15 minutes.
+export async function GET(req: Request) {
+  const authHeader = req.headers.get("Authorization")
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const now = new Date()
+  const windowStart = addHours(now, -1)
+  const windowEnd = addDays(now, 14)
+
+  const bookings = await prisma.booking.findMany({
+    where: {
+      status: "CONFIRMED",
+      meetingId: { not: null },
+      location: "GOOGLE_MEET",
+      endTime: { gte: windowStart, lte: windowEnd },
+    },
+    include: reconcileInclude,
+    take: 200,
+  })
+
+  let cancelled = 0
+  let rescheduled = 0
+  let unchanged = 0
+  let skipped = 0
+  let errored = 0
+
+  for (const b of bookings) {
+    if (!b.meetingId) continue
+    const ev = await getGoogleCalendarEvent(b.userId, b.meetingId)
+
+    if (ev.status === "cancelled") {
+      await reconcileCancellation(b)
+      cancelled++
+      continue
+    }
+    if (ev.status === "not_found") {
+      console.warn(
+        `[calendar-sync] event ${b.meetingId} not_found for booking ${b.id} — leaving as-is`
+      )
+      skipped++
+      continue
+    }
+    if (ev.status === "error") {
+      console.error(
+        `[calendar-sync] error fetching event ${b.meetingId} for booking ${b.id}: ${ev.reason}`
+      )
+      errored++
+      continue
+    }
+
+    const moved =
+      ev.start.getTime() !== b.startTime.getTime() ||
+      ev.end.getTime() !== b.endTime.getTime()
+    if (moved) {
+      await prisma.booking.update({
+        where: { id: b.id },
+        data: { startTime: ev.start, endTime: ev.end },
+      })
+      console.log(
+        `[calendar-sync] rescheduled booking ${b.id}: ${b.startTime.toISOString()} → ${ev.start.toISOString()}`
+      )
+      rescheduled++
+    } else {
+      unchanged++
+    }
+  }
+
+  return NextResponse.json({
+    processed: bookings.length,
+    cancelled,
+    rescheduled,
+    unchanged,
+    skipped,
+    errored,
+  })
+}
+
+async function reconcileCancellation(booking: ReconcileBooking) {
+  await prisma.booking.update({
+    where: { id: booking.id },
+    data: { status: "CANCELLED", cancelReason: "Cancelled in calendar" },
+  })
+
+  const dateTimeStr = format(
+    toZonedTime(booking.startTime, booking.bookerTimezone),
+    "EEEE, MMMM d, yyyy 'at' h:mm a"
+  )
+
+  try {
+    await sendEmail({
+      to: booking.bookerEmail,
+      subject: `Cancelled: ${booking.title}`,
+      html: bookingCancelledEmail({
+        name: booking.bookerName,
+        eventTitle: booking.title,
+        dateTime: dateTimeStr,
+        reason: "Cancelled in calendar",
+      }),
+    })
+    if (booking.eventType.user.email) {
+      await sendEmail({
+        to: booking.eventType.user.email,
+        subject: `Booking cancelled: ${booking.title} with ${booking.bookerName}`,
+        html: bookingCancelledEmail({
+          name: booking.eventType.user.name || "Host",
+          eventTitle: booking.title,
+          dateTime: dateTimeStr,
+          reason: "Cancelled in calendar",
+        }),
+      })
+    }
+  } catch (e) {
+    console.error(`[calendar-sync] cancel email failed for booking ${booking.id}:`, e)
+  }
+
+  try {
+    const payload = await buildBookingPayload(booking.id)
+    if (payload) await triggerWebhooks(booking.userId, "booking.cancelled", payload)
+  } catch (e) {
+    console.error(`[calendar-sync] webhook fanout failed for booking ${booking.id}:`, e)
+  }
+
+  console.log(`[calendar-sync] cancelled booking ${booking.id} (event removed from calendar)`)
+}

--- a/src/lib/calendar/google.ts
+++ b/src/lib/calendar/google.ts
@@ -112,6 +112,39 @@ export async function createGoogleCalendarEvent(
   }
 }
 
+export type GoogleEventLookup =
+  | { status: "ok"; start: Date; end: Date }
+  | { status: "cancelled" }
+  | { status: "not_found" }
+  | { status: "error"; reason: string }
+
+// Read a single event by id. Used by the reconcile cron to detect when the
+// host moved or deleted the event directly in Google Calendar. Returns the
+// event status alongside its time window so callers can diff and decide.
+export async function getGoogleCalendarEvent(
+  userId: string,
+  eventId: string
+): Promise<GoogleEventLookup> {
+  const calendar = await getGoogleCalendarClient(userId)
+  if (!calendar) return { status: "error", reason: "no_google_client" }
+
+  try {
+    const res = await calendar.events.get({ calendarId: "primary", eventId })
+    const ev = res.data
+    if (ev.status === "cancelled") return { status: "cancelled" }
+    const startStr = ev.start?.dateTime
+    const endStr = ev.end?.dateTime
+    if (!startStr || !endStr) {
+      return { status: "error", reason: "missing_dateTime" }
+    }
+    return { status: "ok", start: new Date(startStr), end: new Date(endStr) }
+  } catch (err: unknown) {
+    const code = (err as { code?: number; status?: number })?.code ?? (err as { code?: number; status?: number })?.status
+    if (code === 404 || code === 410) return { status: "not_found" }
+    return { status: "error", reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
 export async function updateGoogleCalendarEvent(
   userId: string,
   eventId: string,


### PR DESCRIPTION
## Summary
- Adds `GET /api/cron/calendar-sync` to reconcile TinyCal bookings against the host's Google Calendar — picks up events the host moves or deletes directly in their calendar.
- Adds `vercel.json` declaring all three crons. **The repo had no `vercel.json`**, so `reminders` and `webhook-retries` were sitting as routes with no scheduler (confirmed via Vercel API: latest prod deployment reports `crons: []`). This PR wires all three at once.

## Reconcile behavior
- Scope: Google Meet bookings only — their `meetingId` is reliably a Google event id. Outlook is out of scope (event ids aren't persisted today; see `lib/bookings/create.ts:maybeCreateOutlookEvent`).
- Conservative on ambiguity: explicit `status="cancelled"` triggers cancellation; 404/410 is logged and skipped (pre-`isPrimary`-fix bookings may carry a `meetingId` on a different Google account).
- Auto-cancel: writes `status=CANCELLED`, `cancelReason="Cancelled in calendar"`, sends booker + host cancel emails, fires `booking.cancelled` webhook.
- Auto-reschedule: silently updates `startTime`/`endTime`, no booker email. Hosts should use TinyCal's reschedule flow if they want the booker notified.
- Scan window: `endTime` in `[now - 1h, now + 14d]` — far-future bookings come into the window as they approach.

## Cron schedules
| Path | Schedule | Why |
|---|---|---|
| `/api/cron/reminders` | `*/15 * * * *` | Route comment says "every 15 minutes"; filters on `reminderSentAt: null` + start within next hour, so enabling is safe — no historical replay. |
| `/api/cron/webhook-retries` | `* * * * *` | Route comment notes 1-min granularity is fine; smallest backoff is 30s. |
| `/api/cron/calendar-sync` | `*/15 * * * *` | New in this PR. |

## Heads up
- Enabling `webhook-retries` for the first time will flush any pending failed deliveries with `nextAttemptAt <= now`. If there's a backlog, expect a burst on the first tick after merge.
- Enabling `reminders` for the first time will email any confirmed bookings starting in the next hour that don't yet have `reminderSentAt`. Small population, but worth a glance at recent bookings before merge.
- Crons need Pro tier or higher for sub-daily intervals. The project is already running webhooks and bookings in prod, so this should be fine.

## Test plan
- [ ] After merge, in the Vercel dashboard verify three crons are listed and have run at least once.
- [ ] Manually invoke: `curl -H "Authorization: Bearer $CRON_SECRET" https://tinycal.zenithstudio.app/api/cron/calendar-sync` — expect `{ processed, cancelled, rescheduled, unchanged, skipped, errored }`.
- [ ] Move a Google Meet booking 30 min later directly in Google Calendar → next tick → `/dashboard/bookings` shows new time.
- [ ] Delete the same booking in Google Calendar → next tick → booking flips to `CANCELLED`, booker + host get cancel email, `booking.cancelled` webhook fires.
- [ ] Confirm `reminders` continues to send 1-hour pre-meeting emails as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)