### PR TITLE
chore(vercel): declare crons so they actually run

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/webhook-retries",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/calendar-sync",
+      "schedule": "*/15 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
The repo has no `vercel.json`, so all three `/api/cron/*` routes have been sitting unscheduled — confirmed via the Vercel API: the latest production deployment reports `crons: []`. Reminders and webhook retries weren't running before this PR; `/api/cron/calendar-sync` (merged in #71) won't either until this lands.

This file declares the schedule for all three.

## Schedules
| Path | Schedule | Why |
|---|---|---|
| `/api/cron/reminders` | `*/15 * * * *` | Route comment says "every 15 minutes". Filters on `reminderSentAt: null` + start within next hour, so first run has at most a tiny near-future backlog. |
| `/api/cron/webhook-retries` | `* * * * *` | Route comment notes 1-min granularity is fine; smallest backoff is 30s. |
| `/api/cron/calendar-sync` | `*/15 * * * *` | New reconcile cron from #71. |

## Heads up before merging
- **Webhook-retries**: first tick after merge will flush any `PENDING` deliveries with `nextAttemptAt <= now`. If there's a backlog, expect a burst.
- **Reminders**: first tick will email any confirmed bookings starting in the next hour that don't yet have `reminderSentAt`. Small population, but worth a glance at upcoming bookings.
- **Plan tier**: sub-daily cron intervals require Pro or higher. The project runs webhooks + bookings in prod, so this should be fine.

## Test plan
- [ ] After merge, Vercel dashboard shows three crons and they run on schedule.
- [ ] `curl -H "Authorization: Bearer \$CRON_SECRET" https://tinycal.zenithstudio.app/api/cron/calendar-sync` returns the summary JSON.
- [ ] Move a Google Meet booking 30 min later directly in Google Calendar → next tick → `/dashboard/bookings` reflects the new time.
- [ ] Delete the same booking in Google Calendar → next tick → status flips to `CANCELLED`, cancel emails fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)