### PR TITLE
fix(cron): trim CRON_SECRET so trailing whitespace doesn't 401

### DIFF
--- a/src/app/api/cron/calendar-sync/route.ts
+++ b/src/app/api/cron/calendar-sync/route.ts
@@ -7,6 +7,7 @@ import { getGoogleCalendarEvent } from "@/lib/calendar/google"
 import { sendEmail, bookingCancelledEmail } from "@/lib/email"
 import { triggerWebhooks } from "@/lib/webhooks"
 import { buildBookingPayload } from "@/lib/webhooks/booking-payload"
+import { isAuthorizedCronRequest } from "@/lib/cron-auth"
 
 const reconcileInclude = {
   eventType: { include: { user: true } },
@@ -28,8 +29,7 @@ type ReconcileBooking = Prisma.BookingGetPayload<{ include: typeof reconcileIncl
 //
 // Recommended schedule: every 15 minutes.
 export async function GET(req: Request) {
-  const authHeader = req.headers.get("Authorization")
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!isAuthorizedCronRequest(req)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -4,13 +4,12 @@ import { sendEmail, bookingReminderEmail } from "@/lib/email"
 import { sendSMS, bookingReminderSMS } from "@/lib/sms"
 import { format } from "date-fns"
 import { toZonedTime } from "date-fns-tz"
+import { isAuthorizedCronRequest } from "@/lib/cron-auth"
 
 // Called by cron job every 15 minutes
 // Sends reminders 1 hour before meetings
 export async function GET(req: Request) {
-  // Verify cron secret
-  const authHeader = req.headers.get("Authorization")
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!isAuthorizedCronRequest(req)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/src/app/api/cron/webhook-retries/route.ts
+++ b/src/app/api/cron/webhook-retries/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import prisma from "@/lib/prisma"
 import { attemptHttpDelivery, persistAttemptResult } from "@/lib/webhooks"
+import { isAuthorizedCronRequest } from "@/lib/cron-auth"
 
 // Cron-driven retry of failed webhook deliveries.
 //
@@ -12,8 +13,7 @@ import { attemptHttpDelivery, persistAttemptResult } from "@/lib/webhooks"
 // Recommended schedule: every 1–2 minutes. 30s is the smallest backoff so
 // 1min granularity is fine.
 export async function GET(req: Request) {
-  const authHeader = req.headers.get("Authorization")
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!isAuthorizedCronRequest(req)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -1,0 +1,10 @@
+// Shared bearer-token check for /api/cron/* routes.
+//
+// process.env.CRON_SECRET is trimmed because Vercel's `env add` CLI flows
+// (and other paste-into-dashboard flows) can leave a trailing newline that
+// turns a strict `Bearer ${secret}` comparison into a silent 401.
+export function isAuthorizedCronRequest(req: Request): boolean {
+  const expected = process.env.CRON_SECRET?.trim()
+  if (!expected) return false
+  return req.headers.get("Authorization") === `Bearer ${expected}`
+}


### PR DESCRIPTION
## Summary
The three `/api/cron/*` routes used strict-equality bearer comparison against \`Bearer \${process.env.CRON_SECRET}\`. When the env var is added via piped CLI input, here-string, or pasted into the dashboard, a trailing newline can sneak in — the runtime then reads `"<hex>\n"` and every request, including Vercel's own scheduled invocations, 401s silently.

This is also a live blocker right now. I generated and added `CRON_SECRET` to the production env after #72 merged, but `curl -H "Authorization: Bearer $secret" .../api/cron/calendar-sync` keeps returning 401 against `tinycal.zenithstudio.app`, which matches exactly this trailing-whitespace failure mode.

## Change
- New `src/lib/cron-auth.ts` with `isAuthorizedCronRequest(req)` that reads `process.env.CRON_SECRET`, trims it, and does the bearer comparison.
- All three cron routes call the helper instead of inlining the check.
- No semantic change beyond the trim — if the env value has no whitespace, behavior is identical.

## Test plan
- [ ] After merge + auto-deploy, `curl -H "Authorization: Bearer \$CRON_SECRET" https://tinycal.zenithstudio.app/api/cron/calendar-sync` returns JSON summary (not 401).
- [ ] Same for `/api/cron/reminders` and `/api/cron/webhook-retries`.
- [ ] Vercel dashboard → Crons tab shows green runs at the next scheduled tick for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)