### PR TITLE
fix(cron): exempt /api/cron from session middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,8 @@ const publicRoutes = [
   '/api/webhooks', '/api/availability', '/api/bookings',
   '/api/slots', '/api/stripe/webhook', '/api/auth',
   '/api/meeting-links',
-  '/api/v1',  // REST API — auths via Bearer api key in route handler
+  '/api/v1',   // REST API — auths via Bearer api key in route handler
+  '/api/cron', // cron routes — auth via Bearer CRON_SECRET in route handler
 ]
 
 function isPublicRoute(pathname: string): boolean {


### PR DESCRIPTION
## The actual bug

Auth.js middleware (\`src/middleware.ts\`) was eating every \`/api/cron/*\` request before the route handler ran:

\`\`\`
< HTTP/2 401
< set-cookie: __Host-authjs.csrf-token=...
< set-cookie: __Secure-authjs.callback-url=...
{"error":"Unauthorized"}
\`\`\`

The auth.js cookies in the response are the smoking gun — that's not the route's 401 (which would have just been \`{error:"Unauthorized"}\` with no auth cookies). The middleware returns 401 for any \`/api/\` path not in \`publicRoutes\`, and \`/api/cron\` wasn't on the list.

This means **the cron routes' own \`Bearer \$CRON_SECRET\` check has never executed in production** — neither for my curl probes, nor for Vercel's scheduled invocations. All the env-var fumbling earlier was a red herring; the request never got past the middleware.

## Fix

Add \`/api/cron\` to \`publicRoutes\`. Same pattern as \`/api/webhooks\`, \`/api/v1\`, \`/api/stripe/webhook\`, etc. — routes that authenticate via Bearer/signature in their own handler must be exempt from session-cookie gating. The route's existing \`isAuthorizedCronRequest(req)\` check still enforces auth.

## Test plan
- [ ] After merge + auto-deploy, hit each route with the bearer:
  \`\`\`
  curl -H "Authorization: Bearer \$CRON_SECRET" https://tinycal.zenithstudio.app/api/cron/calendar-sync
  curl -H "Authorization: Bearer \$CRON_SECRET" https://tinycal.zenithstudio.app/api/cron/reminders
  curl -H "Authorization: Bearer \$CRON_SECRET" https://tinycal.zenithstudio.app/api/cron/webhook-retries
  \`\`\`
  Each should return JSON summary, not the auth.js 401.
- [ ] Unauth requests still 401 (now from the route's own handler, no auth.js cookies in response).
- [ ] Next scheduled tick from Vercel does real work — check the Crons tab in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)