### PR TITLE
fix(TD-0045): show collective event types in co-host's dashboard

### DIFF
--- a/src/__tests__/api/event-types-id.test.ts
+++ b/src/__tests__/api/event-types-id.test.ts
@@ -31,6 +31,7 @@ import { GET, PATCH, DELETE } from "@/app/api/event-types/[id]/route"
 
 const OWNER = { id: "owner-1" } as any
 const OTHER = { id: "other-1" } as any
+const COHOST = { id: "alex-id" } as any
 
 const SOLO_ET = {
   id: "et-1",
@@ -81,6 +82,41 @@ describe("GET /api/event-types/[id]", () => {
     mockEventTypeFindFirst.mockResolvedValueOnce(null)
     const res = await GET(new Request("http://x"), { params: { id: "et-1" } })
     expect(res.status).toBe(404)
+  })
+
+  it("queries with OR(userId, collective+member) so co-hosts can read the event type", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(COHOST)
+    mockEventTypeFindFirst.mockResolvedValueOnce(COLLECTIVE_ET)
+    mockUserFindMany.mockResolvedValueOnce([])
+
+    await GET(new Request("http://x"), { params: { id: "et-1" } })
+
+    expect(mockEventTypeFindFirst).toHaveBeenCalledTimes(1)
+    const arg = mockEventTypeFindFirst.mock.calls[0][0]
+    expect(arg.where).toEqual({
+      id: "et-1",
+      OR: [
+        { userId: "alex-id" },
+        { isCollective: true, collectiveMembers: { has: "alex-id" } },
+      ],
+    })
+  })
+
+  it("tags viewerRole=CO_HOST when viewer is a co-host but not the owner", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(COHOST)
+    mockEventTypeFindFirst.mockResolvedValueOnce(COLLECTIVE_ET)
+    mockUserFindMany.mockResolvedValueOnce([])
+    const res = await GET(new Request("http://x"), { params: { id: "et-1" } })
+    const body = await res.json()
+    expect(body.viewerRole).toBe("CO_HOST")
+  })
+
+  it("tags viewerRole=OWNER when viewer owns the event type", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(OWNER)
+    mockEventTypeFindFirst.mockResolvedValueOnce(SOLO_ET)
+    const res = await GET(new Request("http://x"), { params: { id: "et-1" } })
+    const body = await res.json()
+    expect(body.viewerRole).toBe("OWNER")
   })
 })
 

--- a/src/__tests__/api/event-types-route.test.ts
+++ b/src/__tests__/api/event-types-route.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockEventTypeFindMany = vi.fn()
+const mockEventTypeCount = vi.fn()
+const mockEventTypeCreate = vi.fn()
+const mockAvailabilityScheduleFindFirst = vi.fn()
+const mockGetAuthenticatedUser = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    eventType: {
+      findMany: (...args: any[]) => mockEventTypeFindMany(...args),
+      count: (...args: any[]) => mockEventTypeCount(...args),
+      create: (...args: any[]) => mockEventTypeCreate(...args),
+    },
+    availabilitySchedule: {
+      findFirst: (...args: any[]) => mockAvailabilityScheduleFindFirst(...args),
+    },
+  },
+}))
+
+vi.mock("@/lib/auth", () => ({
+  getAuthenticatedUser: (...args: any[]) => mockGetAuthenticatedUser(...args),
+}))
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return { ...actual, generateSlug: (s: string) => s.toLowerCase().replace(/\s+/g, "-") }
+})
+
+import { GET, POST } from "@/app/api/event-types/route"
+
+const OWNER = { id: "owner-1", plan: "PRO" } as any
+const COHOST = { id: "cohost-1", plan: "PRO" } as any
+
+describe("GET /api/event-types", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns 401 when no authenticated user", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(null)
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it("queries with OR(userId, collective+member) so co-hosts also see the event type", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(COHOST)
+    mockEventTypeFindMany.mockResolvedValueOnce([])
+
+    await GET()
+
+    expect(mockEventTypeFindMany).toHaveBeenCalledTimes(1)
+    const arg = mockEventTypeFindMany.mock.calls[0][0]
+    expect(arg.where).toEqual({
+      OR: [
+        { userId: "cohost-1" },
+        { isCollective: true, collectiveMembers: { has: "cohost-1" } },
+      ],
+    })
+    // Owner summary needed for the dashboard to render co-hosted events correctly.
+    expect(arg.include.user.select).toMatchObject({
+      id: true, name: true, email: true, slug: true,
+    })
+  })
+
+  it("tags each row with viewerRole=OWNER vs CO_HOST based on userId", async () => {
+    mockGetAuthenticatedUser.mockResolvedValueOnce(COHOST)
+    mockEventTypeFindMany.mockResolvedValueOnce([
+      { id: "et-mine", userId: "cohost-1", title: "My own", isCollective: false, collectiveMembers: [] },
+      { id: "et-shared", userId: "owner-1", title: "Discovery call", isCollective: true, collectiveMembers: ["cohost-1"] },
+    ])
+
+    const res = await GET()
+    const body = await res.json()
+    expect(body).toHaveLength(2)
+    expect(body[0]).toMatchObject({ id: "et-mine", viewerRole: "OWNER" })
+    expect(body[1]).toMatchObject({ id: "et-shared", viewerRole: "CO_HOST" })
+  })
+})
+
+describe("POST /api/event-types", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAuthenticatedUser.mockResolvedValue(OWNER)
+    mockEventTypeCreate.mockResolvedValue({ id: "new" })
+  })
+
+  it("creates an event type for an authenticated user", async () => {
+    const res = await POST(
+      new Request("http://x", {
+        method: "POST",
+        body: JSON.stringify({ title: "Quick chat" }),
+      })
+    )
+    expect(res.status).toBe(200)
+    expect(mockEventTypeCreate).toHaveBeenCalled()
+  })
+})

--- a/src/app/api/event-types/[id]/route.ts
+++ b/src/app/api/event-types/[id]/route.ts
@@ -12,9 +12,20 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   const user = await getAuthenticatedUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
+  // Co-hosts on a collective event type are allowed to view (read-only); the
+  // PATCH/DELETE handlers below still gate mutation on ownership.
   const eventType = await prisma.eventType.findFirst({
-    where: { id: params.id, userId: user.id },
-    include: { questions: { orderBy: { order: "asc" } } },
+    where: {
+      id: params.id,
+      OR: [
+        { userId: user.id },
+        { isCollective: true, collectiveMembers: { has: user.id } },
+      ],
+    },
+    include: {
+      questions: { orderBy: { order: "asc" } },
+      user: { select: { id: true, name: true, email: true, slug: true } },
+    },
   })
   if (!eventType) return NextResponse.json({ error: "Not found" }, { status: 404 })
 
@@ -29,7 +40,8 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     })
   }
 
-  return NextResponse.json({ ...eventType, collectiveHosts })
+  const viewerRole = eventType.userId === user.id ? ("OWNER" as const) : ("CO_HOST" as const)
+  return NextResponse.json({ ...eventType, collectiveHosts, viewerRole })
 }
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {

--- a/src/app/api/event-types/route.ts
+++ b/src/app/api/event-types/route.ts
@@ -7,12 +7,31 @@ export async function GET() {
   const user = await getAuthenticatedUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
+  // Co-hosts on a collective event type need to see it in their own dashboard,
+  // not just the owner. The booking/slots layer (src/app/api/slots/route.ts)
+  // already treats every member as a host, so visibility was the only gap.
+  // `isCollective: true` is required so flipping collective scheduling off
+  // re-hides the event from former co-hosts.
   const eventTypes = await prisma.eventType.findMany({
-    where: { userId: user.id },
-    include: { questions: { orderBy: { order: "asc" } }, _count: { select: { bookings: true } } },
+    where: {
+      OR: [
+        { userId: user.id },
+        { isCollective: true, collectiveMembers: { has: user.id } },
+      ],
+    },
+    include: {
+      questions: { orderBy: { order: "asc" } },
+      _count: { select: { bookings: true } },
+      user: { select: { id: true, name: true, email: true, slug: true } },
+    },
     orderBy: { createdAt: "desc" },
   })
-  return NextResponse.json(eventTypes)
+
+  const decorated = eventTypes.map((et) => ({
+    ...et,
+    viewerRole: et.userId === user.id ? ("OWNER" as const) : ("CO_HOST" as const),
+  }))
+  return NextResponse.json(decorated)
 }
 
 export async function POST(req: Request) {

--- a/src/app/dashboard/event-types/[id]/page.tsx
+++ b/src/app/dashboard/event-types/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useRouter, useParams } from "next/navigation"
-import { ArrowLeft, Save, X, AlertCircle } from "lucide-react"
+import { ArrowLeft, Save, X, AlertCircle, Users } from "lucide-react"
 import Link from "next/link"
 
 interface CoHost {
@@ -133,11 +133,16 @@ export default function EditEventTypePage() {
 
   if (!et) return <div className="animate-pulse">Loading...</div>
 
+  const isCoHost = et.viewerRole === "CO_HOST"
+  const readOnly = isCoHost
   const showsEmptyCollectiveWarning =
-    et.isCollective && (et.collectiveMembers ?? []).length === 0
+    !isCoHost && et.isCollective && (et.collectiveMembers ?? []).length === 0
 
   const previewHost = typeof window !== "undefined" ? window.location.host : "tinycal.zenithstudio.app"
-  const slugUrlPreview = userSlug ? `${previewHost}/${userSlug}/${et.slug}` : null
+  // For co-hosted events the booking page lives under the owner's slug, not the
+  // viewer's — using the viewer's slug here would render a 404 link.
+  const ownerSlug = isCoHost ? (et.user?.slug ?? "") : userSlug
+  const slugUrlPreview = ownerSlug ? `${previewHost}/${ownerSlug}/${et.slug}` : null
 
   return (
     <div>
@@ -145,10 +150,21 @@ export default function EditEventTypePage() {
         <Link href="/dashboard/event-types" className="p-2 hover:bg-gray-100 rounded-lg">
           <ArrowLeft className="w-4 h-4" />
         </Link>
-        <h1 className="text-2xl font-bold">Edit Event Type</h1>
+        <h1 className="text-2xl font-bold">{readOnly ? "Event Type" : "Edit Event Type"}</h1>
       </div>
 
-      <div className="bg-white border rounded-xl p-6 space-y-6">
+      {readOnly && (
+        <div className="mb-4 flex items-start gap-2 text-sm text-blue-800 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3">
+          <Users className="w-4 h-4 flex-shrink-0 mt-0.5" />
+          <div>
+            You&apos;re a <strong>co-host</strong> on this event type. Only the
+            owner{et.user?.name ? ` (${et.user.name})` : et.user?.email ? ` (${et.user.email})` : ""} can edit it —
+            reach out to them if something needs to change.
+          </div>
+        </div>
+      )}
+
+      <fieldset disabled={readOnly} className="bg-white border rounded-xl p-6 space-y-6 disabled:opacity-90">
         <div>
           <label className="block text-sm font-medium mb-1">Title</label>
           <input type="text" value={et.title} onChange={e => setEt({ ...et, title: e.target.value })}
@@ -368,13 +384,15 @@ export default function EditEventTypePage() {
           </div>
         )}
 
-        <div className="flex justify-end">
-          <button onClick={handleSave} disabled={saving || !!slugError}
-            className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2">
-            <Save className="w-4 h-4" /> {saving ? "Saving..." : "Save Changes"}
-          </button>
-        </div>
-      </div>
+        {!readOnly && (
+          <div className="flex justify-end">
+            <button onClick={handleSave} disabled={saving || !!slugError}
+              className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2">
+              <Save className="w-4 h-4" /> {saving ? "Saving..." : "Save Changes"}
+            </button>
+          </div>
+        )}
+      </fieldset>
     </div>
   )
 }

--- a/src/app/dashboard/event-types/page.tsx
+++ b/src/app/dashboard/event-types/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef } from "react"
 import Link from "next/link"
-import { Plus, Copy, Pencil, Trash2, Calendar, Search, X } from "lucide-react"
+import { Plus, Copy, Pencil, Trash2, Calendar, Search, X, Users } from "lucide-react"
 import { formatDuration } from "@/lib/utils"
 
 function useDebounce(value: string, delay: number) {
@@ -61,6 +61,7 @@ export default function EventTypesPage() {
   }
 
   function copyLink(slug: string, userSlug: string) {
+    if (!userSlug) return
     navigator.clipboard.writeText(`${window.location.origin}/${userSlug}/${slug}`)
   }
 
@@ -176,7 +177,11 @@ export default function EventTypesPage() {
             <button onClick={() => { setSearch(""); searchRef.current?.focus() }}
               className="text-blue-600 text-sm hover:underline mt-2 inline-block">Clear search</button>
           </div>
-        ) : filteredEventTypes.map((et) => (
+        ) : filteredEventTypes.map((et) => {
+          const isCoHost = et.viewerRole === "CO_HOST"
+          // Co-hosted events live under the owner's booking URL, not the viewer's.
+          const bookingSlug = isCoHost ? (et.user?.slug || "") : (user?.slug || "")
+          return (
           <div key={et.id} className="bg-white border rounded-xl p-5 flex items-center justify-between hover:shadow-sm transition">
             <Link
               href={`/dashboard/event-types/${et.id}`}
@@ -184,31 +189,47 @@ export default function EventTypesPage() {
             >
               <div className="w-2 h-12 rounded-full flex-shrink-0" style={{ backgroundColor: et.color }} />
               <div className="min-w-0">
-                <h3 className="font-semibold truncate">{et.title}</h3>
+                <div className="flex items-center gap-2">
+                  <h3 className="font-semibold truncate">{et.title}</h3>
+                  {isCoHost && (
+                    <span
+                      className="inline-flex items-center gap-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded px-1.5 py-0.5"
+                      title={`Owned by ${et.user?.name || et.user?.email || "another host"}`}
+                    >
+                      <Users className="w-3 h-3" /> Co-host
+                    </span>
+                  )}
+                </div>
                 <p className="text-sm text-gray-500 truncate">
                   {formatDuration(et.duration)} · {et.location.replace("_", " ")} · {et._count?.bookings || 0} bookings
+                  {isCoHost && et.user?.name ? ` · with ${et.user.name}` : ""}
                 </p>
               </div>
             </Link>
             <div className="flex items-center gap-2 ml-3">
-              <button onClick={() => copyLink(et.slug, user?.slug || "")}
-                className="p-2 hover:bg-gray-100 rounded-lg"
-                title="Copy booking page link" aria-label="Copy booking page link">
+              <button onClick={() => copyLink(et.slug, bookingSlug)}
+                disabled={!bookingSlug}
+                className="p-2 hover:bg-gray-100 rounded-lg disabled:opacity-40 disabled:cursor-not-allowed"
+                title={bookingSlug ? "Copy booking page link" : "Owner hasn't published a public booking page yet"}
+                aria-label="Copy booking page link">
                 <Copy className="w-4 h-4 text-gray-500" />
               </button>
               <Link href={`/dashboard/event-types/${et.id}`}
                 className="p-2 hover:bg-gray-100 rounded-lg"
-                title="Edit" aria-label="Edit event type">
+                title={isCoHost ? "View (read-only)" : "Edit"} aria-label="View event type">
                 <Pencil className="w-4 h-4 text-gray-500" />
               </Link>
-              <button onClick={() => handleDelete(et.id)}
-                className="p-2 hover:bg-gray-100 rounded-lg"
-                title="Delete" aria-label="Delete event type">
-                <Trash2 className="w-4 h-4 text-red-500" />
-              </button>
+              {!isCoHost && (
+                <button onClick={() => handleDelete(et.id)}
+                  className="p-2 hover:bg-gray-100 rounded-lg"
+                  title="Delete" aria-label="Delete event type">
+                  <Trash2 className="w-4 h-4 text-red-500" />
+                </button>
+              )}
             </div>
           </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #78

## Summary
A user added as **co-host** on a collective event type couldn't see it in their own TinyCal event-types list because both `GET /api/event-types` and `GET /api/event-types/[id]` filtered strictly on `userId = currentUser.id`. The booking layer already treats every `collectiveMembers` entry as a host (see `src/app/api/slots/route.ts:41` and `src/lib/bookings/conflict-check.ts:27`), so this was purely a list/detail visibility gap, not a scheduling bug.

- List + detail queries now match `userId` **OR** (`isCollective: true` AND `collectiveMembers has user.id`). The `isCollective: true` gate ensures that flipping collective scheduling off re-hides the event from former co-hosts.
- Responses include `user { id, name, email, slug }` for the owner and a `viewerRole: "OWNER" | "CO_HOST"` flag so the dashboard can build the correct booking URL (it lives under the **owner's** slug) and hide owner-only actions.
- `PATCH` and `DELETE` stay owner-only — co-hosts get a read-only edit screen with a banner pointing at the owner.
- Dashboard listing shows a small "Co-host" badge next to events the viewer doesn't own, suppresses the delete button, and disables the copy-link button when the owner hasn't published a public slug yet.

## Test plan
- [x] `vitest run` — 275/275 pass, including new `event-types-route.test.ts` (4 tests) and added co-host coverage in `event-types-id.test.ts` (now 19 tests).
- [x] Existing PATCH/DELETE 403 tests still pass — co-hosts cannot mutate.
- [x] `next lint` — no new warnings.
- [ ] Manual: as owner, add a co-host on a collective event type; sign in as co-host and confirm the event appears in their dashboard with a "Co-host" badge, the edit screen is read-only, and the copy-link button uses the owner's booking slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)