### PR TITLE
fix(TD-0044): add 20 minute meeting option

### DIFF
--- a/docs/design/08-ui-specifications.md
+++ b/docs/design/08-ui-specifications.md
@@ -430,7 +430,7 @@ Each stat card:
 | Field | Type | Placeholder |
 |-------|------|-------------|
 | Title | text input | "e.g. 30 Minute Meeting" |
-| Duration | select | [15, 30, 45, 60, 90, 120] minutes |
+| Duration | select | [15, 20, 30, 45, 60, 90, 120] minutes |
 | Location | select | Google Meet, Zoom, Phone, In Person, Custom |
 | Description | textarea | "Optional" |
 

--- a/src/app/dashboard/event-types/[id]/page.tsx
+++ b/src/app/dashboard/event-types/[id]/page.tsx
@@ -182,7 +182,7 @@ export default function EditEventTypePage() {
             <label className="block text-sm font-medium mb-1">Duration (min)</label>
             <select value={et.duration} onChange={e => setEt({ ...et, duration: Number(e.target.value) })}
               className="w-full border rounded-lg px-3 py-2">
-              {[15, 30, 45, 60, 90, 120].map(d => <option key={d} value={d}>{d}</option>)}
+              {[15, 20, 30, 45, 60, 90, 120].map(d => <option key={d} value={d}>{d}</option>)}
             </select>
           </div>
           <div>

--- a/src/app/dashboard/event-types/page.tsx
+++ b/src/app/dashboard/event-types/page.tsx
@@ -126,7 +126,7 @@ export default function EventTypesPage() {
                 <label className="block text-sm font-medium mb-1">Duration (minutes)</label>
                 <select value={form.duration} onChange={e => setForm({ ...form, duration: Number(e.target.value) })}
                   className="w-full border rounded-lg px-3 py-2">
-                  {[15, 30, 45, 60, 90, 120].map(d => (
+                  {[15, 20, 30, 45, 60, 90, 120].map(d => (
                     <option key={d} value={d}>{formatDuration(d)}</option>
                   ))}
                 </select>


### PR DESCRIPTION
Implements #77.

Changes:
- Adds 20 minutes to event type duration options in create/edit flows.
- Updates the UI spec duration list.

Verification from local worker:
- Targeted typecheck showed no new errors in touched files.
- Booking/webhook vitest suite passed (29/29).
- `next lint` only reported pre-existing warnings.