### PR TITLE
Add cancel and reschedule actions to bookings dashboard (TD-0046)

### DIFF
--- a/src/app/dashboard/bookings/page.tsx
+++ b/src/app/dashboard/bookings/page.tsx
@@ -4,11 +4,13 @@ import { useEffect, useState, useRef } from "react"
 import Link from "next/link"
 import { format } from "date-fns"
 import { Clock, ChevronLeft, ChevronRight, Search, X } from "lucide-react"
+import { Modal } from "@/components/ui/modal"
 
 const PAGE_SIZE = 10
 
 interface Booking {
   id: string
+  uid: string
   title: string
   startTime: string
   endTime: string
@@ -34,6 +36,10 @@ export default function BookingsPage() {
   const [search, setSearch] = useState("")
   const debouncedSearch = useDebounce(search, 300)
   const searchRef = useRef<HTMLInputElement>(null)
+  const [cancelTarget, setCancelTarget] = useState<Booking | null>(null)
+  const [cancelReason, setCancelReason] = useState("")
+  const [cancelling, setCancelling] = useState(false)
+  const [cancelError, setCancelError] = useState<string | null>(null)
 
   useEffect(() => {
     fetch("/api/bookings").then(r => r.json()).then(setBookings)
@@ -61,6 +67,51 @@ export default function BookingsPage() {
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
   const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+
+  function openCancel(b: Booking) {
+    setCancelTarget(b)
+    setCancelReason("")
+    setCancelError(null)
+  }
+
+  function closeCancel() {
+    if (cancelling) return
+    setCancelTarget(null)
+    setCancelReason("")
+    setCancelError(null)
+  }
+
+  async function confirmCancel() {
+    if (!cancelTarget) return
+    setCancelling(true)
+    setCancelError(null)
+    try {
+      const res = await fetch(`/api/bookings/${cancelTarget.uid}/cancel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: cancelReason || undefined }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setCancelError(data.error || "Failed to cancel booking")
+        setCancelling(false)
+        return
+      }
+      setBookings(prev =>
+        prev.map(b => (b.id === cancelTarget.id ? { ...b, status: "CANCELLED" } : b))
+      )
+      setCancelTarget(null)
+      setCancelReason("")
+    } catch {
+      setCancelError("Network error. Please try again.")
+    } finally {
+      setCancelling(false)
+    }
+  }
+
+  function isActionable(b: Booking) {
+    return b.status === "CONFIRMED" && new Date(b.startTime) > new Date()
+  }
 
   return (
     <div>
@@ -118,23 +169,41 @@ export default function BookingsPage() {
             )}
           </div>
         ) : paginated.map(b => (
-          <div key={b.id} className="p-4 flex items-center justify-between">
-            <div>
-              <p className="font-medium">{b.title}</p>
+          <div key={b.id} className="p-4 flex items-center justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <p className="font-medium truncate">{b.title}</p>
               <p className="text-sm text-gray-600">
                 {format(new Date(b.startTime), "EEE, MMM d, yyyy")} at {format(new Date(b.startTime), "h:mm a")} — {format(new Date(b.endTime), "h:mm a")}
               </p>
-              <p className="text-sm text-gray-500">{b.bookerName} · {b.bookerEmail}</p>
+              <p className="text-sm text-gray-500 truncate">{b.bookerName} · {b.bookerEmail}</p>
               {b.meetingUrl && (
-                <a href={b.meetingUrl} target="_blank" className="text-sm text-blue-600 hover:underline">Join meeting</a>
+                <a href={b.meetingUrl} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 hover:underline">Join meeting</a>
               )}
             </div>
-            <span className={`text-xs px-2 py-1 rounded-full ${
-              b.status === "CONFIRMED" ? "bg-green-100 text-green-700" :
-              b.status === "CANCELLED" ? "bg-red-100 text-red-700" :
-              b.status === "RESCHEDULED" ? "bg-yellow-100 text-yellow-700" :
-              "bg-gray-100 text-gray-700"
-            }`}>{b.status}</span>
+            <div className="flex items-center gap-2 shrink-0">
+              {isActionable(b) && (
+                <>
+                  <Link
+                    href={`/reschedule/${b.uid}`}
+                    className="text-sm px-3 py-1.5 border rounded-lg text-gray-700 hover:bg-gray-50"
+                  >
+                    Reschedule
+                  </Link>
+                  <button
+                    onClick={() => openCancel(b)}
+                    className="text-sm px-3 py-1.5 border border-red-200 rounded-lg text-red-600 hover:bg-red-50"
+                  >
+                    Cancel
+                  </button>
+                </>
+              )}
+              <span className={`text-xs px-2 py-1 rounded-full ${
+                b.status === "CONFIRMED" ? "bg-green-100 text-green-700" :
+                b.status === "CANCELLED" ? "bg-red-100 text-red-700" :
+                b.status === "RESCHEDULED" ? "bg-yellow-100 text-yellow-700" :
+                "bg-gray-100 text-gray-700"
+              }`}>{b.status}</span>
+            </div>
           </div>
         ))}
       </div>
@@ -168,6 +237,49 @@ export default function BookingsPage() {
           </div>
         </div>
       )}
+
+      <Modal open={!!cancelTarget} onClose={closeCancel} title="Cancel booking">
+        {cancelTarget && (
+          <div>
+            <p className="text-sm text-gray-600 mb-1">
+              Cancel <span className="font-medium text-gray-900">{cancelTarget.title}</span> with{" "}
+              <span className="font-medium text-gray-900">{cancelTarget.bookerName}</span>?
+            </p>
+            <p className="text-sm text-gray-500 mb-4">
+              {format(new Date(cancelTarget.startTime), "EEE, MMM d, yyyy")} at {format(new Date(cancelTarget.startTime), "h:mm a")}
+            </p>
+            <label className="block text-sm font-medium mb-1" htmlFor="cancel-reason">
+              Reason (optional)
+            </label>
+            <textarea
+              id="cancel-reason"
+              value={cancelReason}
+              onChange={e => setCancelReason(e.target.value)}
+              className="w-full border rounded-lg px-3 py-2 h-24 resize-none text-sm"
+              placeholder="Shared with the booker in the cancellation email."
+            />
+            {cancelError && (
+              <p className="mt-3 text-sm text-red-600 bg-red-50 rounded-lg p-3">{cancelError}</p>
+            )}
+            <div className="flex gap-2 mt-4">
+              <button
+                onClick={closeCancel}
+                disabled={cancelling}
+                className="flex-1 border py-2 rounded-lg text-sm hover:bg-gray-50 disabled:opacity-50"
+              >
+                Keep booking
+              </button>
+              <button
+                onClick={confirmCancel}
+                disabled={cancelling}
+                className="flex-1 bg-red-600 text-white py-2 rounded-lg text-sm hover:bg-red-700 disabled:opacity-50"
+              >
+                {cancelling ? "Cancelling..." : "Cancel booking"}
+              </button>
+            </div>
+          </div>
+        )}
+      </Modal>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Resolves [#81](https://github.com/zenithventure/tinycal/issues/81) — `TD-0046: add event cancellation and reschedule in the calendar details`.

The host's `/dashboard/bookings` page listed bookings but did not surface cancel/reschedule actions, so hosts had to dig out the booker's self-service link from their email to manage their own calendar. Upcoming confirmed rows now show inline **Reschedule** and **Cancel** controls.

- **Reschedule** routes to the existing `/reschedule/<uid>` flow, reusing the same slot-picker / availability logic and the `POST /api/bookings/<uid>/reschedule` endpoint (no duplication).
- **Cancel** opens a Modal with an optional reason textarea and POSTs to `/api/bookings/<uid>/cancel`. The booking row is optimistically updated to `CANCELLED` on success so it slides into the Cancelled tab without a refetch.
- Buttons only render for `CONFIRMED` bookings whose `startTime` is in the future; past, cancelled, and rescheduled rows continue to show just the status badge.

## Test plan

- [x] `npm run test` — 275/275 vitest tests pass
- [x] `npx tsc --noEmit` — no new TypeScript errors (pre-existing errors in stripe/auth/skeleton are unchanged)
- [x] `npm run lint` — no new lint warnings/errors introduced by this change
- [ ] Manual: log into the dashboard, open an upcoming booking, click Reschedule → slot picker loads / confirms
- [ ] Manual: click Cancel → modal opens, reason optional, booker + host receive cancellation email, row moves to Cancelled tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)