### PR TITLE
fix(TD-0047): sync Google Calendar deletions to bookings

### DIFF
--- a/src/__tests__/api/cron-calendar-sync.test.ts
+++ b/src/__tests__/api/cron-calendar-sync.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockBookingFindMany = vi.fn()
+const mockBookingUpdate = vi.fn()
+const mockGetGoogleCalendarEvent = vi.fn()
+const mockSendEmail = vi.fn()
+const mockTriggerWebhooks = vi.fn()
+const mockBuildBookingPayload = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    booking: {
+      findMany: (...args: any[]) => mockBookingFindMany(...args),
+      update: (...args: any[]) => mockBookingUpdate(...args),
+    },
+  },
+}))
+
+vi.mock("@/lib/calendar/google", () => ({
+  getGoogleCalendarEvent: (...args: any[]) => mockGetGoogleCalendarEvent(...args),
+}))
+
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: any[]) => mockSendEmail(...args),
+  bookingCancelledEmail: ({ reason }: { reason: string }) => `cancelled-email:${reason}`,
+}))
+
+vi.mock("@/lib/webhooks", () => ({
+  triggerWebhooks: (...args: any[]) => mockTriggerWebhooks(...args),
+}))
+
+vi.mock("@/lib/webhooks/booking-payload", () => ({
+  buildBookingPayload: (...args: any[]) => mockBuildBookingPayload(...args),
+}))
+
+import { GET } from "@/app/api/cron/calendar-sync/route"
+
+const SECRET = "test-cron-secret"
+
+function makeReq(token = SECRET): Request {
+  return new Request("http://localhost/api/cron/calendar-sync", {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+function makeBooking(overrides: Partial<any> = {}) {
+  return {
+    id: "b-1",
+    uid: "u-1",
+    userId: "user-1",
+    title: "Intro call",
+    startTime: new Date("2026-06-01T10:00:00Z"),
+    endTime: new Date("2026-06-01T10:30:00Z"),
+    bookerName: "Alex Booker",
+    bookerEmail: "booker@example.com",
+    bookerTimezone: "America/New_York",
+    meetingId: "google-event-1",
+    location: "GOOGLE_MEET",
+    eventType: {
+      user: { email: "host@example.com", name: "Host" },
+    },
+    ...overrides,
+  }
+}
+
+describe("GET /api/cron/calendar-sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = SECRET
+    mockBookingUpdate.mockResolvedValue({})
+    mockSendEmail.mockResolvedValue({})
+    mockBuildBookingPayload.mockResolvedValue({ event: "booking.cancelled" })
+    mockTriggerWebhooks.mockResolvedValue(undefined)
+  })
+
+  it("returns 401 without the cron secret", async () => {
+    const res = await GET(new Request("http://x/api/cron/calendar-sync"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 401 with the wrong cron secret", async () => {
+    const res = await GET(makeReq("wrong"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns zeros when no bookings match", async () => {
+    mockBookingFindMany.mockResolvedValueOnce([])
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ processed: 0, cancelled: 0, rescheduled: 0, unchanged: 0, skipped: 0, errored: 0 })
+  })
+
+  it("cancels the booking when Google returns status=cancelled", async () => {
+    mockBookingFindMany.mockResolvedValueOnce([makeBooking()])
+    mockGetGoogleCalendarEvent.mockResolvedValueOnce({ status: "cancelled" })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body).toMatchObject({ processed: 1, cancelled: 1 })
+    expect(mockBookingUpdate).toHaveBeenCalledWith({
+      where: { id: "b-1" },
+      data: { status: "CANCELLED", cancelReason: "Cancelled in calendar" },
+    })
+    expect(mockSendEmail).toHaveBeenCalledTimes(2)
+    expect(mockTriggerWebhooks).toHaveBeenCalledWith("user-1", "booking.cancelled", expect.any(Object))
+  })
+
+  it("cancels the booking when Google returns 410 (gone)", async () => {
+    mockBookingFindMany.mockResolvedValueOnce([makeBooking()])
+    mockGetGoogleCalendarEvent.mockResolvedValueOnce({ status: "gone" })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body).toMatchObject({ processed: 1, cancelled: 1 })
+    expect(mockBookingUpdate).toHaveBeenCalledWith({
+      where: { id: "b-1" },
+      data: { status: "CANCELLED", cancelReason: "Deleted from calendar" },
+    })
+    expect(mockTriggerWebhooks).toHaveBeenCalledWith("user-1", "booking.cancelled", expect.any(Object))
+  })
+
+  it("skips the booking when Google returns 404 (not_found) without cancelling", async () => {
+    mockBookingFindMany.mockResolvedValueOnce([makeBooking()])
+    mockGetGoogleCalendarEvent.mockResolvedValueOnce({ status: "not_found" })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body).toMatchObject({ processed: 1, skipped: 1, cancelled: 0 })
+    expect(mockBookingUpdate).not.toHaveBeenCalled()
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it("reports errored when Google lookup fails", async () => {
+    mockBookingFindMany.mockResolvedValueOnce([makeBooking()])
+    mockGetGoogleCalendarEvent.mockResolvedValueOnce({ status: "error", reason: "boom" })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body).toMatchObject({ processed: 1, errored: 1 })
+    expect(mockBookingUpdate).not.toHaveBeenCalled()
+  })
+
+  it("reschedules the booking when Google times changed", async () => {
+    mockBookingFindMany.mockResolvedValueOnce([makeBooking()])
+    const newStart = new Date("2026-06-01T11:00:00Z")
+    const newEnd = new Date("2026-06-01T11:30:00Z")
+    mockGetGoogleCalendarEvent.mockResolvedValueOnce({ status: "ok", start: newStart, end: newEnd })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body).toMatchObject({ processed: 1, rescheduled: 1 })
+    expect(mockBookingUpdate).toHaveBeenCalledWith({
+      where: { id: "b-1" },
+      data: { startTime: newStart, endTime: newEnd },
+    })
+  })
+
+  it("counts as unchanged when times match", async () => {
+    const booking = makeBooking()
+    mockBookingFindMany.mockResolvedValueOnce([booking])
+    mockGetGoogleCalendarEvent.mockResolvedValueOnce({ status: "ok", start: booking.startTime, end: booking.endTime })
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(body).toMatchObject({ processed: 1, unchanged: 1 })
+    expect(mockBookingUpdate).not.toHaveBeenCalled()
+  })
+
+  it("scans bookings up to 90 days in the future so far-out deletions are caught", async () => {
+    mockBookingFindMany.mockResolvedValueOnce([])
+    await GET(makeReq())
+    const where = mockBookingFindMany.mock.calls[0][0].where
+    const lookahead = where.endTime.lte.getTime() - Date.now()
+    // Allow 1 day slack on either side; the contract is "well past the previous 14-day cap".
+    expect(lookahead).toBeGreaterThan(60 * 24 * 60 * 60 * 1000)
+    expect(lookahead).toBeLessThan(95 * 24 * 60 * 60 * 1000)
+  })
+})

--- a/src/app/api/cron/calendar-sync/route.ts
+++ b/src/app/api/cron/calendar-sync/route.ts
@@ -23,9 +23,16 @@ type ReconcileBooking = Prisma.BookingGetPayload<{ include: typeof reconcileIncl
 // guaranteed to be a Google calendar event id. Outlook event ids aren't stored
 // on Booking today, so Outlook reconcile is a separate task.
 //
-// 404/410 from Google is treated as ambiguous (could be a stale connection on
-// a pre-primary-fix booking) and is logged + skipped rather than auto-cancelled.
-// Only an explicit status="cancelled" triggers cancellation.
+// Deletion handling:
+//  - status="cancelled" from Google → cancel (event still listed as cancelled).
+//  - 410 Gone → cancel (event has been deleted; this is the terminal state once
+//    Google purges the cancelled tombstone).
+//  - 404 Not Found → ambiguous (could be a stale connection on a pre-primary-fix
+//    booking where meetingId belongs to a different calendar). Logged + skipped.
+//
+// Window: looks ahead far enough to cover the longest booking horizon allowed
+// by EventType.maxFutureDays (default 60). 90 days gives a buffer for hosts
+// who raise the cap without leaving deletions silently un-synced for weeks.
 //
 // Recommended schedule: every 15 minutes.
 export async function GET(req: Request) {
@@ -35,7 +42,7 @@ export async function GET(req: Request) {
 
   const now = new Date()
   const windowStart = addHours(now, -1)
-  const windowEnd = addDays(now, 14)
+  const windowEnd = addDays(now, 90)
 
   const bookings = await prisma.booking.findMany({
     where: {
@@ -58,14 +65,15 @@ export async function GET(req: Request) {
     if (!b.meetingId) continue
     const ev = await getGoogleCalendarEvent(b.userId, b.meetingId)
 
-    if (ev.status === "cancelled") {
-      await reconcileCancellation(b)
+    if (ev.status === "cancelled" || ev.status === "gone") {
+      const reason = ev.status === "gone" ? "Deleted from calendar" : "Cancelled in calendar"
+      await reconcileCancellation(b, reason)
       cancelled++
       continue
     }
     if (ev.status === "not_found") {
       console.warn(
-        `[calendar-sync] event ${b.meetingId} not_found for booking ${b.id} — leaving as-is`
+        `[calendar-sync] event ${b.meetingId} not_found (404) for booking ${b.id} — leaving as-is (possible stale connection)`
       )
       skipped++
       continue
@@ -105,10 +113,10 @@ export async function GET(req: Request) {
   })
 }
 
-async function reconcileCancellation(booking: ReconcileBooking) {
+async function reconcileCancellation(booking: ReconcileBooking, reason: string) {
   await prisma.booking.update({
     where: { id: booking.id },
-    data: { status: "CANCELLED", cancelReason: "Cancelled in calendar" },
+    data: { status: "CANCELLED", cancelReason: reason },
   })
 
   const dateTimeStr = format(
@@ -124,7 +132,7 @@ async function reconcileCancellation(booking: ReconcileBooking) {
         name: booking.bookerName,
         eventTitle: booking.title,
         dateTime: dateTimeStr,
-        reason: "Cancelled in calendar",
+        reason,
       }),
     })
     if (booking.eventType.user.email) {
@@ -135,7 +143,7 @@ async function reconcileCancellation(booking: ReconcileBooking) {
           name: booking.eventType.user.name || "Host",
           eventTitle: booking.title,
           dateTime: dateTimeStr,
-          reason: "Cancelled in calendar",
+          reason,
         }),
       })
     }
@@ -150,5 +158,5 @@ async function reconcileCancellation(booking: ReconcileBooking) {
     console.error(`[calendar-sync] webhook fanout failed for booking ${booking.id}:`, e)
   }
 
-  console.log(`[calendar-sync] cancelled booking ${booking.id} (event removed from calendar)`)
+  console.log(`[calendar-sync] cancelled booking ${booking.id}: ${reason}`)
 }

--- a/src/lib/calendar/google.ts
+++ b/src/lib/calendar/google.ts
@@ -115,12 +115,19 @@ export async function createGoogleCalendarEvent(
 export type GoogleEventLookup =
   | { status: "ok"; start: Date; end: Date }
   | { status: "cancelled" }
+  | { status: "gone" }
   | { status: "not_found" }
   | { status: "error"; reason: string }
 
 // Read a single event by id. Used by the reconcile cron to detect when the
 // host moved or deleted the event directly in Google Calendar. Returns the
 // event status alongside its time window so callers can diff and decide.
+//
+// 410 Gone is split out from 404 because Google returns 410 specifically when
+// an event has been deleted (it lingers as `status: "cancelled"` for a window,
+// then 410). A 404 could also mean the eventId was never on this calendar —
+// e.g. a pre-primary-fix booking written to a different connection. Callers
+// treat "gone" as a confirmed deletion and "not_found" as ambiguous.
 export async function getGoogleCalendarEvent(
   userId: string,
   eventId: string
@@ -140,7 +147,8 @@ export async function getGoogleCalendarEvent(
     return { status: "ok", start: new Date(startStr), end: new Date(endStr) }
   } catch (err: unknown) {
     const code = (err as { code?: number; status?: number })?.code ?? (err as { code?: number; status?: number })?.status
-    if (code === 404 || code === 410) return { status: "not_found" }
+    if (code === 410) return { status: "gone" }
+    if (code === 404) return { status: "not_found" }
     return { status: "error", reason: err instanceof Error ? err.message : String(err) }
   }
 }


### PR DESCRIPTION
## Summary

When a host deletes an appointment in Google Calendar, TinyCal now syncs that deletion onto the booking — status flips to `CANCELLED`, cancellation emails go out, and the `booking.cancelled` webhook fires. Closes #82.

Two narrow bugs in `/api/cron/calendar-sync` were silently dropping deletions:

- **Look-ahead capped at 14 days** while `EventType.maxFutureDays` defaults to 60 — deletions on bookings more than two weeks out stayed un-reconciled for up to ~6 weeks. Window extended to **90 days**.
- **Google API 410 Gone was treated as ambiguous** along with 404. 410 means the event was purged after cancellation — that's a definitive deletion. Split the lookup type so 410 → `gone` (cancel) and 404 → `not_found` (still skipped, preserving the pre-primary-fix safety net).

For a CONFIRMED future booking whose host deleted the event in Google Calendar UI, the booking now reconciles within one cron tick (15 min) whether the API returns `status: "cancelled"` or 410.

The dashboard Bookings *Cancel* button side of the report ("cannot delete from the web admin interface under Bookings") is being delivered in PR #83 (TD-0046).

### Files changed

- `src/lib/calendar/google.ts` — `GoogleEventLookup` gains a `gone` variant; 410 maps to it, 404 stays `not_found`.
- `src/app/api/cron/calendar-sync/route.ts` — cancel on `cancelled` OR `gone`; cancel reason reflects which path triggered it; window widened to 90 days.
- `src/__tests__/api/cron-calendar-sync.test.ts` — new test file (10 cases) covering auth, the new 410/gone path, the existing cancelled/reschedule/unchanged paths, the 404 skip, the error counter, and the widened window.

## Test plan

- [x] `npx vitest run src/__tests__/api/cron-calendar-sync.test.ts` — 10/10 pass
- [x] `npx vitest run` — 285/285 pass (no regressions)
- [x] `npx tsc --noEmit` — no new errors (all reported errors pre-exist on `main`: stripe SDK + `auth.ts` + `skeleton`)
- [x] `npx next lint` — no new errors (only `@typescript-eslint/no-explicit-any` warnings, consistent with existing test files like `cron-webhook-retries.test.ts`)

## Verification on a deployment

1. Create a GOOGLE_MEET booking with start time 30 days out.
2. Delete the event in Google Calendar UI.
3. Wait one cron tick (≤15 min) or hit `/api/cron/calendar-sync` with the cron secret.
4. Booking row should move to the **Cancelled** tab with reason `Cancelled in calendar`. Booker should receive a cancellation email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)