### PR TITLE
[TD-0048] Add dark mode with cookie-persisted preference

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -9,20 +9,20 @@ function LoginForm() {
   const error = searchParams.get("error")
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <h1 className="text-2xl font-bold text-blue-600 mb-2">
-            Tiny<span className="text-gray-900">Cal</span>
+            Tiny<span className="text-gray-900 dark:text-gray-100">Cal</span>
           </h1>
-          <p className="text-gray-600">Welcome back</p>
+          <p className="text-gray-600 dark:text-gray-400">Welcome back</p>
         </div>
 
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <div className="bg-white dark:bg-gray-950 rounded-lg shadow-sm border border-gray-200 dark:border-gray-800 p-6">
           {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
+            <div className="mb-4 p-3 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-md text-sm text-red-700 dark:text-red-300">
               <p className="font-medium">Authentication error: {error}</p>
-              <p className="mt-1 text-xs text-red-500 break-all">
+              <p className="mt-1 text-xs text-red-500 dark:text-red-400 break-all">
                 Full URL: {typeof window !== 'undefined' ? window.location.href : ''}
               </p>
             </div>
@@ -30,7 +30,7 @@ function LoginForm() {
           <button
             onClick={() => signIn("google", { callbackUrl: "/dashboard" })}
             type="button"
-            className="w-full py-2 px-4 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition flex items-center justify-center gap-2"
+            className="w-full py-2 px-4 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-md text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition flex items-center justify-center gap-2"
           >
             <svg className="w-4 h-4" viewBox="0 0 24 24">
               <path
@@ -60,7 +60,7 @@ function LoginForm() {
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading...</div>}>
+    <Suspense fallback={<div className="min-h-screen flex items-center justify-center dark:bg-gray-900 dark:text-gray-100">Loading...</div>}>
       <LoginForm />
     </Suspense>
   )

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation"
 import { Calendar, Clock, Settings, Webhook, LayoutDashboard, LogOut, Users, Menu, X, LifeBuoy, Link2, KeyRound } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/lib/contexts/auth-context"
+import { ThemeToggle } from "@/components/ui/theme-toggle"
 
 const navItems = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
@@ -44,29 +45,34 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-screen flex items-center justify-center dark:bg-gray-900">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 dark:text-gray-100">
       {/* Top bar */}
-      <header className="bg-white border-b h-14 flex items-center px-4 md:px-6 sticky top-0 z-50">
+      <header className="bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-800 h-14 flex items-center px-4 md:px-6 sticky top-0 z-50">
         <button
           onClick={() => setMobileMenuOpen(true)}
-          className="md:hidden mr-3 p-1 text-gray-600 hover:text-gray-900"
+          className="md:hidden mr-3 p-1 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
           aria-label="Open menu"
         >
           <Menu className="w-5 h-5" />
         </button>
         <Link href="/dashboard" className="text-lg font-bold text-blue-600">
-          Tiny<span className="text-gray-900">Cal</span>
+          Tiny<span className="text-gray-900 dark:text-gray-100">Cal</span>
         </Link>
-        <div className="ml-auto flex items-center gap-4">
-          <span className="text-sm text-gray-600 hidden sm:inline">{user?.email}</span>
-          <button onClick={handleSignOut} className="text-sm text-gray-500 hover:text-gray-700">
+        <div className="ml-auto flex items-center gap-3">
+          <span className="text-sm text-gray-600 dark:text-gray-400 hidden sm:inline">{user?.email}</span>
+          <ThemeToggle />
+          <button
+            onClick={handleSignOut}
+            className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            aria-label="Sign out"
+          >
             <LogOut className="w-4 h-4" />
           </button>
         </div>
@@ -83,17 +89,17 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       {/* Mobile drawer */}
       <aside
         className={cn(
-          "fixed top-0 left-0 h-full w-64 bg-white z-50 transform transition-transform duration-200 ease-in-out md:hidden",
+          "fixed top-0 left-0 h-full w-64 bg-white dark:bg-gray-950 z-50 transform transition-transform duration-200 ease-in-out md:hidden",
           mobileMenuOpen ? "translate-x-0" : "-translate-x-full"
         )}
       >
-        <div className="flex items-center justify-between h-14 px-4 border-b">
+        <div className="flex items-center justify-between h-14 px-4 border-b border-gray-200 dark:border-gray-800">
           <span className="text-lg font-bold text-blue-600">
-            Tiny<span className="text-gray-900">Cal</span>
+            Tiny<span className="text-gray-900 dark:text-gray-100">Cal</span>
           </span>
           <button
             onClick={() => setMobileMenuOpen(false)}
-            className="p-1 text-gray-600 hover:text-gray-900"
+            className="p-1 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
             aria-label="Close menu"
           >
             <X className="w-5 h-5" />
@@ -110,7 +116,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                 onClick={() => setMobileMenuOpen(false)}
                 className={cn(
                   "flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition",
-                  active ? "bg-blue-50 text-blue-700 font-medium" : "text-gray-600 hover:bg-gray-50"
+                  active
+                    ? "bg-blue-50 text-blue-700 font-medium dark:bg-blue-900/30 dark:text-blue-300"
+                    : "text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
                 )}
               >
                 <Icon className="w-4 h-4" />
@@ -123,7 +131,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
       <div className="flex">
         {/* Desktop sidebar */}
-        <aside className="w-56 bg-white border-r min-h-[calc(100vh-3.5rem)] p-4 hidden md:block">
+        <aside className="w-56 bg-white dark:bg-gray-950 border-r border-gray-200 dark:border-gray-800 min-h-[calc(100vh-3.5rem)] p-4 hidden md:block">
           <nav className="space-y-1">
             {navItems.map((item) => {
               const Icon = item.icon
@@ -134,7 +142,9 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                   href={item.href}
                   className={cn(
                     "flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition",
-                    active ? "bg-blue-50 text-blue-700 font-medium" : "text-gray-600 hover:bg-gray-50"
+                    active
+                      ? "bg-blue-50 text-blue-700 font-medium dark:bg-blue-900/30 dark:text-blue-300"
+                      : "text-gray-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
                   )}
                 >
                   <Icon className="w-4 h-4" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,13 @@
 :root {
   --foreground-rgb: 10, 10, 10;
   --background-rgb: 255, 255, 255;
+  color-scheme: light;
+}
+
+.dark {
+  --foreground-rgb: 237, 237, 237;
+  --background-rgb: 17, 24, 39;
+  color-scheme: dark;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
+import { cookies } from "next/headers"
 import "./globals.css"
 import { Providers } from "@/components/providers"
+import { THEME_COOKIE, type Theme } from "@/lib/contexts/theme-context"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -11,10 +13,13 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const cookieTheme = cookies().get(THEME_COOKIE)?.value
+  const theme: Theme = cookieTheme === "dark" ? "dark" : "light"
+
   return (
-    <html lang="en">
+    <html lang="en" className={theme === "dark" ? "dark" : undefined}>
       <body className={inter.className}>
-        <Providers>{children}</Providers>
+        <Providers initialTheme={theme}>{children}</Providers>
       </body>
     </html>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,19 @@
 import Link from "next/link"
 import { Calendar, Check, ArrowRight, Zap } from "lucide-react"
+import { ThemeToggle } from "@/components/ui/theme-toggle"
 
 export default function LandingPage() {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen dark:bg-gray-900 dark:text-gray-100">
       {/* Nav */}
-      <nav className="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50">
+      <nav className="border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-950/80 backdrop-blur-sm sticky top-0 z-50">
         <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
           <Link href="/" className="text-xl font-bold text-blue-600">
-            Tiny<span className="text-gray-900">Cal</span>
+            Tiny<span className="text-gray-900 dark:text-gray-100">Cal</span>
           </Link>
           <div className="flex items-center gap-4">
-            <Link href="/login" className="text-sm text-gray-600 hover:text-gray-900">
+            <ThemeToggle />
+            <Link href="/login" className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100">
               Log in
             </Link>
             <Link
@@ -26,14 +28,14 @@ export default function LandingPage() {
 
       {/* Hero */}
       <section className="max-w-6xl mx-auto px-6 pt-20 pb-16 text-center">
-        <div className="inline-flex items-center gap-2 bg-blue-50 text-blue-700 text-sm px-4 py-1.5 rounded-full mb-6">
+        <div className="inline-flex items-center gap-2 bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 text-sm px-4 py-1.5 rounded-full mb-6">
           <Zap className="w-4 h-4" /> Simple scheduling, starting free
         </div>
-        <h1 className="text-5xl md:text-6xl font-bold tracking-tight text-gray-900 mb-6 text-balance">
+        <h1 className="text-5xl md:text-6xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mb-6 text-balance">
           Schedule meetings.<br />Skip the back-and-forth.<br />
           <span className="text-blue-600">One platform.</span>
         </h1>
-        <p className="text-xl text-gray-600 max-w-2xl mx-auto mb-10">
+        <p className="text-xl text-gray-600 dark:text-gray-400 max-w-2xl mx-auto mb-10">
           Stop overpaying for scheduling. TinyCal gives you professional booking pages,
           calendar sync, and automatic meeting links — simple and affordable.
         </p>
@@ -46,19 +48,19 @@ export default function LandingPage() {
           </Link>
           <Link
             href="#features"
-            className="text-gray-600 px-8 py-3.5 rounded-lg text-lg border hover:bg-gray-50 transition"
+            className="text-gray-600 dark:text-gray-300 px-8 py-3.5 rounded-lg text-lg border border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
           >
             See Features
           </Link>
         </div>
-        <p className="text-sm text-gray-400 mt-4">No credit card required · Free plan available</p>
+        <p className="text-sm text-gray-400 dark:text-gray-500 mt-4">No credit card required · Free plan available</p>
       </section>
 
       {/* Social proof */}
-      <section className="border-y bg-gray-50 py-8">
+      <section className="border-y border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 py-8">
         <div className="max-w-6xl mx-auto px-6 text-center">
-          <p className="text-sm text-gray-500 mb-4">TRUSTED BY FREELANCERS & SMALL BUSINESSES</p>
-          <div className="flex items-center justify-center gap-8 text-gray-400 text-lg font-medium">
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">TRUSTED BY FREELANCERS & SMALL BUSINESSES</p>
+          <div className="flex items-center justify-center gap-8 text-gray-400 dark:text-gray-500 text-lg font-medium">
             <span>Consultants</span>
             <span>·</span>
             <span>Coaches</span>
@@ -73,17 +75,17 @@ export default function LandingPage() {
       {/* Features */}
       <section id="features" className="max-w-6xl mx-auto px-6 py-20">
         <h2 className="text-3xl font-bold text-center mb-4">Everything you need to get booked.</h2>
-        <p className="text-gray-600 text-center mb-12 max-w-xl mx-auto">
+        <p className="text-gray-600 dark:text-gray-400 text-center mb-12 max-w-xl mx-auto">
           Professional scheduling with all the features — none of the bloat.
         </p>
 
         <div className="grid md:grid-cols-2 gap-8 max-w-3xl mx-auto">
-          <div className="border rounded-2xl p-8 hover:shadow-lg transition">
-            <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4">
-              <Calendar className="w-6 h-6 text-blue-600" />
+          <div className="border border-gray-200 dark:border-gray-800 rounded-2xl p-8 hover:shadow-lg dark:hover:shadow-gray-950 transition">
+            <div className="w-12 h-12 bg-blue-100 dark:bg-blue-900/40 rounded-xl flex items-center justify-center mb-4">
+              <Calendar className="w-6 h-6 text-blue-600 dark:text-blue-300" />
             </div>
             <h3 className="text-xl font-semibold mb-3">Smart Scheduling</h3>
-            <p className="text-gray-600 mb-6">
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
               Professional booking pages with calendar sync, timezone detection,
               and automatic meeting links.
             </p>
@@ -98,19 +100,19 @@ export default function LandingPage() {
                 "Embed on your website",
                 "Collective scheduling",
               ].map((f) => (
-                <li key={f} className="flex items-center gap-2 text-sm text-gray-700">
+                <li key={f} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                   <Check className="w-4 h-4 text-green-500 shrink-0" /> {f}
                 </li>
               ))}
             </ul>
           </div>
 
-          <div className="border rounded-2xl p-8 hover:shadow-lg transition">
-            <div className="w-12 h-12 bg-green-100 rounded-xl flex items-center justify-center mb-4">
-              <Check className="w-6 h-6 text-green-600" />
+          <div className="border border-gray-200 dark:border-gray-800 rounded-2xl p-8 hover:shadow-lg dark:hover:shadow-gray-950 transition">
+            <div className="w-12 h-12 bg-green-100 dark:bg-green-900/40 rounded-xl flex items-center justify-center mb-4">
+              <Check className="w-6 h-6 text-green-600 dark:text-green-300" />
             </div>
             <h3 className="text-xl font-semibold mb-3">Built for You</h3>
-            <p className="text-gray-600 mb-6">
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
               Designed for freelancers, consultants, and small teams who want
               scheduling that just works.
             </p>
@@ -125,7 +127,7 @@ export default function LandingPage() {
                 "Daily & weekly booking limits",
                 "Timezone-aware for everyone",
               ].map((f) => (
-                <li key={f} className="flex items-center gap-2 text-sm text-gray-700">
+                <li key={f} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                   <Check className="w-4 h-4 text-green-500 shrink-0" /> {f}
                 </li>
               ))}
@@ -135,7 +137,7 @@ export default function LandingPage() {
       </section>
 
       {/* How it works */}
-      <section className="bg-gray-50 py-20">
+      <section className="bg-gray-50 dark:bg-gray-950 py-20">
         <div className="max-w-6xl mx-auto px-6">
           <h2 className="text-3xl font-bold text-center mb-12">How it works</h2>
           <div className="grid md:grid-cols-3 gap-8">
@@ -149,7 +151,7 @@ export default function LandingPage() {
                   {item.step}
                 </div>
                 <h3 className="font-semibold mb-2">{item.title}</h3>
-                <p className="text-gray-600 text-sm">{item.desc}</p>
+                <p className="text-gray-600 dark:text-gray-400 text-sm">{item.desc}</p>
               </div>
             ))}
           </div>
@@ -159,15 +161,15 @@ export default function LandingPage() {
       {/* Pricing */}
       <section id="pricing" className="max-w-6xl mx-auto px-6 py-20">
         <h2 className="text-3xl font-bold text-center mb-4">Simple, honest pricing</h2>
-        <p className="text-gray-600 text-center mb-12">
+        <p className="text-gray-600 dark:text-gray-400 text-center mb-12">
           No hidden fees. No per-seat pricing. Just one low price for everything.
         </p>
         <div className="grid md:grid-cols-2 gap-8 max-w-3xl mx-auto">
           {/* Free */}
-          <div className="border rounded-2xl p-8">
+          <div className="border border-gray-200 dark:border-gray-800 rounded-2xl p-8">
             <h3 className="text-lg font-semibold mb-1">Free</h3>
             <p className="text-4xl font-bold mb-1">$0</p>
-            <p className="text-gray-500 text-sm mb-6">Forever free</p>
+            <p className="text-gray-500 dark:text-gray-400 text-sm mb-6">Forever free</p>
             <ul className="space-y-2 mb-8">
               {["1 event type", "3 signature sends/mo", "Basic scheduling", "Google Calendar sync"].map((f) => (
                 <li key={f} className="flex items-center gap-2 text-sm">
@@ -175,7 +177,7 @@ export default function LandingPage() {
                 </li>
               ))}
             </ul>
-            <Link href="/login" className="block text-center border border-gray-300 py-2.5 rounded-lg hover:bg-gray-50 transition font-medium">
+            <Link href="/login" className="block text-center border border-gray-300 dark:border-gray-700 py-2.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition font-medium">
               Get Started
             </Link>
           </div>
@@ -186,8 +188,8 @@ export default function LandingPage() {
               MOST POPULAR
             </div>
             <h3 className="text-lg font-semibold mb-1">Pro</h3>
-            <p className="text-4xl font-bold mb-1">$5<span className="text-lg text-gray-500 font-normal">/mo</span></p>
-            <p className="text-gray-500 text-sm mb-6">or $48/year (save 20%)</p>
+            <p className="text-4xl font-bold mb-1">$5<span className="text-lg text-gray-500 dark:text-gray-400 font-normal">/mo</span></p>
+            <p className="text-gray-500 dark:text-gray-400 text-sm mb-6">or $48/year (save 20%)</p>
             <ul className="space-y-2 mb-8">
               {[
                 "Unlimited event types",
@@ -228,15 +230,15 @@ export default function LandingPage() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t py-12">
+      <footer className="border-t border-gray-200 dark:border-gray-800 py-12">
         <div className="max-w-6xl mx-auto px-6 flex flex-col md:flex-row items-center justify-between gap-4">
-          <div className="text-sm text-gray-500">
+          <div className="text-sm text-gray-500 dark:text-gray-400">
             © 2026 TinyCal. All rights reserved.
           </div>
-          <div className="flex items-center gap-6 text-sm text-gray-500">
-            <Link href="/privacy" className="hover:text-gray-700">Privacy</Link>
-            <Link href="/terms" className="hover:text-gray-700">Terms</Link>
-            <a href="mailto:support@tinycal.io" className="hover:text-gray-700">Support</a>
+          <div className="flex items-center gap-6 text-sm text-gray-500 dark:text-gray-400">
+            <Link href="/privacy" className="hover:text-gray-700 dark:hover:text-gray-200">Privacy</Link>
+            <Link href="/terms" className="hover:text-gray-700 dark:hover:text-gray-200">Terms</Link>
+            <a href="mailto:support@tinycal.io" className="hover:text-gray-700 dark:hover:text-gray-200">Support</a>
           </div>
         </div>
       </footer>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,7 +1,18 @@
 "use client"
 
 import { SessionProvider } from "next-auth/react"
+import { ThemeProvider, type Theme } from "@/lib/contexts/theme-context"
 
-export function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>
+export function Providers({
+  children,
+  initialTheme,
+}: {
+  children: React.ReactNode
+  initialTheme: Theme
+}) {
+  return (
+    <SessionProvider>
+      <ThemeProvider initialTheme={initialTheme}>{children}</ThemeProvider>
+    </SessionProvider>
+  )
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -2,13 +2,13 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const variantClasses = {
-  success: "bg-green-100 text-green-700",
-  warning: "bg-yellow-100 text-yellow-700",
-  danger: "bg-red-100 text-red-700",
-  neutral: "bg-gray-100 text-gray-700",
-  info: "bg-blue-100 text-blue-700",
-  pro: "bg-blue-100 text-blue-700",
-  purple: "bg-purple-100 text-purple-700",
+  success: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+  warning: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300",
+  danger: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+  neutral: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  info: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  pro: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  purple: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
 } as const
 
 type BadgeVariant = keyof typeof variantClasses

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,13 +3,13 @@ import { cn } from "@/lib/utils"
 
 const variantClasses = {
   primary:
-    "bg-blue-600 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+    "bg-blue-600 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900",
   secondary:
-    "border border-gray-300 text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+    "border border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900",
   danger:
-    "bg-red-600 text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500 focus:ring-offset-2",
+    "bg-red-600 text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900",
   ghost:
-    "text-gray-600 hover:bg-gray-100 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
+    "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900",
 } as const
 
 const sizeClasses = {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,3 +15,5 @@ export type { SkeletonProps } from "./skeleton"
 
 export { ToastProvider, useToast } from "./toast"
 export type { ToastVariant, ToastContextValue } from "./toast"
+
+export { ThemeToggle } from "./theme-toggle"

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -13,9 +13,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           ref={ref}
           className={cn(
             "w-full border rounded-lg px-3 py-2 text-sm outline-none transition focus:ring-2",
+            "bg-white text-gray-900 placeholder:text-gray-400",
+            "dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500",
             error
               ? "border-red-500 focus:ring-red-500"
-              : "border-gray-300 focus:ring-blue-500 focus:border-blue-500",
+              : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 focus:border-blue-500",
             "disabled:opacity-50 disabled:cursor-not-allowed",
             className
           )}
@@ -26,7 +28,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         {error && (
           <p
             id={props.id ? `${props.id}-error` : undefined}
-            className="text-sm text-red-600 mt-1"
+            className="text-sm text-red-600 dark:text-red-400 mt-1"
           >
             {error}
           </p>

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -30,7 +30,7 @@ function Modal({ open, onClose, title, children, className }: ModalProps) {
     >
       <div
         className={cn(
-          "bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6",
+          "bg-white dark:bg-gray-900 dark:text-gray-100 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6",
           className
         )}
         onClick={(e) => e.stopPropagation()}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import * as React from "react"
+import { Moon, Sun } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useTheme } from "@/lib/contexts/theme-context"
+
+type ThemeToggleProps = React.ButtonHTMLAttributes<HTMLButtonElement>
+
+const ThemeToggle = React.forwardRef<HTMLButtonElement, ThemeToggleProps>(
+  ({ className, ...props }, ref) => {
+    const { theme, toggleTheme } = useTheme()
+    const isDark = theme === "dark"
+    const label = isDark ? "Switch to light mode" : "Switch to dark mode"
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={toggleTheme}
+        aria-label={label}
+        title={label}
+        className={cn(
+          "p-1.5 rounded-md text-gray-500 hover:text-gray-900 hover:bg-gray-100",
+          "dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-800",
+          "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition",
+          className
+        )}
+        {...props}
+      >
+        {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+      </button>
+    )
+  }
+)
+
+ThemeToggle.displayName = "ThemeToggle"
+
+export { ThemeToggle }

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -22,10 +22,14 @@ interface ToastContextValue {
 // --- Variant config ---
 
 const variantClasses = {
-  success: "bg-green-100 text-green-700 border-green-200",
-  error: "bg-red-50 text-red-600 border-red-200",
-  warning: "bg-yellow-100 text-yellow-700 border-yellow-200",
-  info: "bg-blue-50 text-blue-700 border-blue-200",
+  success:
+    "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/40 dark:text-green-200 dark:border-green-800",
+  error:
+    "bg-red-50 text-red-600 border-red-200 dark:bg-red-950/50 dark:text-red-200 dark:border-red-900",
+  warning:
+    "bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/40 dark:text-yellow-200 dark:border-yellow-800",
+  info:
+    "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/50 dark:text-blue-200 dark:border-blue-900",
 } as const
 
 const variantIcons = {

--- a/src/lib/contexts/theme-context.tsx
+++ b/src/lib/contexts/theme-context.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import * as React from "react"
+
+export type Theme = "light" | "dark"
+
+export const THEME_COOKIE = "tinycal_theme"
+const COOKIE_MAX_AGE_DAYS = 365
+
+interface ThemeContextValue {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(undefined)
+
+function writeThemeCookie(theme: Theme) {
+  if (typeof document === "undefined") return
+  const maxAge = COOKIE_MAX_AGE_DAYS * 24 * 60 * 60
+  document.cookie = `${THEME_COOKIE}=${theme}; path=/; max-age=${maxAge}; SameSite=Lax`
+}
+
+function applyThemeClass(theme: Theme) {
+  if (typeof document === "undefined") return
+  const root = document.documentElement
+  if (theme === "dark") {
+    root.classList.add("dark")
+  } else {
+    root.classList.remove("dark")
+  }
+}
+
+export function ThemeProvider({
+  initialTheme,
+  children,
+}: {
+  initialTheme: Theme
+  children: React.ReactNode
+}) {
+  const [theme, setThemeState] = React.useState<Theme>(initialTheme)
+
+  React.useEffect(() => {
+    applyThemeClass(theme)
+  }, [theme])
+
+  const setTheme = React.useCallback((next: Theme) => {
+    setThemeState(next)
+    writeThemeCookie(next)
+  }, [])
+
+  const toggleTheme = React.useCallback(() => {
+    setThemeState((prev) => {
+      const next: Theme = prev === "dark" ? "light" : "dark"
+      writeThemeCookie(next)
+      return next
+    })
+  }, [])
+
+  const value = React.useMemo(
+    () => ({ theme, setTheme, toggleTheme }),
+    [theme, setTheme, toggleTheme]
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = React.useContext(ThemeContext)
+  if (!ctx) {
+    throw new Error("useTheme must be used within a ThemeProvider")
+  }
+  return ctx
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss"
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
Closes #85

## Summary
- Enable Tailwind class-based dark mode and add a `ThemeProvider` that persists the user's choice in the `tinycal_theme` cookie (SameSite=Lax, 365 days).
- Read the cookie in the root layout (server side) to set `<html class="dark">` for the initial render, avoiding a light-mode flash before hydration.
- Add a Sun/Moon `ThemeToggle` to the dashboard top bar and the marketing nav.
- Apply `dark:` variants to high-traffic surfaces: landing page, login, dashboard chrome, and shared UI primitives (button, input, badge, modal, toast).

## Test plan
- [x] `npm run lint` — clean for the new/changed files (pre-existing warnings/errors elsewhere untouched).
- [x] `npm test` — 285/285 passing.
- [x] `next build` — succeeds with placeholder env.
- [ ] Manual: toggle from dashboard header, reload page, confirm theme persists via cookie.
- [ ] Manual: log out / land on `/`, toggle, navigate to `/login`, confirm cookie carries the preference.