### PR TITLE
fix(bookings): deliver collective meetings to every co-host (Google Meet)

### DIFF
--- a/src/lib/bookings/__tests__/create.test.ts
+++ b/src/lib/bookings/__tests__/create.test.ts
@@ -5,6 +5,7 @@ const mockEventTypeFindUnique = vi.fn()
 const mockBookingCreate = vi.fn()
 const mockContactUpsert = vi.fn()
 const mockCalendarConnectionFindFirst = vi.fn()
+const mockUserFindMany = vi.fn()
 const mockHasBookingConflict = vi.fn()
 const mockCreateGoogleCalendarEvent = vi.fn()
 const mockCreateZoomMeeting = vi.fn()
@@ -19,6 +20,7 @@ vi.mock("@/lib/prisma", () => ({
     booking: { create: (...args: any[]) => mockBookingCreate(...args) },
     contact: { upsert: (...args: any[]) => mockContactUpsert(...args) },
     calendarConnection: { findFirst: (...args: any[]) => mockCalendarConnectionFindFirst(...args) },
+    user: { findMany: (...args: any[]) => mockUserFindMany(...args) },
   },
 }))
 
@@ -91,6 +93,7 @@ describe("createBooking", () => {
     mockBuildBookingPayload.mockResolvedValue({ booking: {}, eventType: {}, host: {} })
     mockCalendarConnectionFindFirst.mockResolvedValue(null)
     mockTriggerWebhooks.mockResolvedValue({})
+    mockUserFindMany.mockResolvedValue([])
   })
 
   describe("error paths", () => {
@@ -205,6 +208,103 @@ describe("createBooking", () => {
     it("does NOT create an Outlook event for GOOGLE_MEET bookings", async () => {
       await createBooking(VALID_INPUT)
       expect(mockCreateOutlookCalendarEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("collective event types (Google Meet)", () => {
+    const COLLECTIVE_EVENT_TYPE = {
+      ...SOLO_EVENT_TYPE,
+      isCollective: true,
+      collectiveMembers: ["cohost-1", "cohost-2"],
+    }
+
+    beforeEach(() => {
+      mockEventTypeFindUnique.mockResolvedValue(COLLECTIVE_EVENT_TYPE)
+      mockUserFindMany.mockResolvedValue([
+        { email: "cohost1@example.com" },
+        { email: "cohost2@example.com" },
+      ])
+    })
+
+    it("includes every co-host email as a Google attendee on the owner's event", async () => {
+      await createBooking(VALID_INPUT)
+      expect(mockCreateGoogleCalendarEvent).toHaveBeenCalledWith(
+        "host-1",
+        expect.objectContaining({
+          attendees: [
+            { email: "alex@example.com" },
+            { email: "cohost1@example.com" },
+            { email: "cohost2@example.com" },
+          ],
+          conferenceData: true,
+        })
+      )
+    })
+
+    it("resolves co-host emails by querying the collectiveMembers ids", async () => {
+      await createBooking(VALID_INPUT)
+      expect(mockUserFindMany).toHaveBeenCalledWith({
+        where: { id: { in: ["cohost-1", "cohost-2"] } },
+        select: { email: true },
+      })
+    })
+
+    it("drops co-hosts that have no email on record from the attendee list", async () => {
+      mockUserFindMany.mockResolvedValue([
+        { email: "cohost1@example.com" },
+        { email: null },
+      ])
+      await createBooking(VALID_INPUT)
+      expect(mockCreateGoogleCalendarEvent).toHaveBeenCalledWith(
+        "host-1",
+        expect.objectContaining({
+          attendees: [
+            { email: "alex@example.com" },
+            { email: "cohost1@example.com" },
+          ],
+        })
+      )
+    })
+
+    it("sends a host confirmation email to the owner AND every co-host", async () => {
+      await createBooking(VALID_INPUT)
+      const hostEmailRecipients = mockSendEmail.mock.calls
+        .map((c) => c[0]?.to)
+        .filter((to) => to !== "alex@example.com") // drop the booker's email
+      expect(hostEmailRecipients).toEqual(
+        expect.arrayContaining([
+          "sze@example.com",
+          "cohost1@example.com",
+          "cohost2@example.com",
+        ])
+      )
+      expect(hostEmailRecipients).toHaveLength(3)
+    })
+
+    it("deduplicates the host email recipient list if a co-host is also the owner", async () => {
+      mockUserFindMany.mockResolvedValue([
+        { email: "sze@example.com" }, // same as owner
+        { email: "cohost2@example.com" },
+      ])
+      await createBooking(VALID_INPUT)
+      const hostEmailRecipients = mockSendEmail.mock.calls
+        .map((c) => c[0]?.to)
+        .filter((to) => to !== "alex@example.com")
+      expect(hostEmailRecipients.sort()).toEqual(
+        ["cohost2@example.com", "sze@example.com"].sort()
+      )
+    })
+
+    it("does NOT query users or pad attendees for non-collective event types", async () => {
+      mockEventTypeFindUnique.mockResolvedValue(SOLO_EVENT_TYPE)
+      await createBooking(VALID_INPUT)
+      expect(mockUserFindMany).not.toHaveBeenCalled()
+      expect(mockCreateGoogleCalendarEvent).toHaveBeenCalledWith(
+        "host-1",
+        expect.objectContaining({
+          attendees: [{ email: "alex@example.com" }],
+        })
+      )
     })
   })
 })

--- a/src/lib/bookings/create.ts
+++ b/src/lib/bookings/create.ts
@@ -105,12 +105,22 @@ async function generateMeeting(
   end: Date
 ): Promise<{ meetingUrl?: string; meetingId?: string }> {
   if (eventType.location === "GOOGLE_MEET") {
+    // For collective event types, add co-hosts as Google attendees on the
+    // owner's event so Google sends them an invite, surfaces the Meet link,
+    // and (once they accept) drops the event onto their primary calendar —
+    // which is what getConflictingEvents reads for future scans. Without
+    // this, only the owner ever sees the meeting and co-hosts can be
+    // double-booked because their calendar holds nothing about it.
+    const coHostEmails = await getCollectiveCoHostEmails(eventType)
     const calEvent = await createGoogleCalendarEvent(eventType.userId, {
       summary: `${eventType.title} - ${input.bookerName}`,
       description: `Booked via TinyCal`,
       startTime: start,
       endTime: end,
-      attendees: [{ email: input.bookerEmail }],
+      attendees: [
+        { email: input.bookerEmail },
+        ...coHostEmails.map((email) => ({ email })),
+      ],
       conferenceData: true,
     })
     return { meetingUrl: calEvent?.meetingUrl ?? undefined, meetingId: calEvent?.id ?? undefined }
@@ -156,10 +166,21 @@ async function sendConfirmationEmails(
     console.error("Email send failed:", e)
   }
 
-  if (eventType.user.email) {
+  // Owner + collective co-hosts all need a "new booking" notification. Google
+  // Calendar will email attendees when conferenceData is created, but only if
+  // the co-host's email is on a Google-hosted mailbox; routing through our
+  // own template ensures everyone gets a TinyCal-styled confirmation with
+  // reschedule/cancel links regardless of provider.
+  const coHostEmails = await getCollectiveCoHostEmails(eventType)
+  const hostEmails = [eventType.user.email, ...coHostEmails].filter(
+    (e): e is string => Boolean(e)
+  )
+  const uniqueHostEmails = Array.from(new Set(hostEmails))
+
+  for (const hostEmail of uniqueHostEmails) {
     try {
       await sendEmail({
-        to: eventType.user.email,
+        to: hostEmail,
         subject: `New booking: ${eventType.title} with ${booking.bookerName}`,
         html: bookingConfirmationEmail({
           bookerName: eventType.user.name || "Host",
@@ -177,6 +198,22 @@ async function sendConfirmationEmails(
       console.error("Host email send failed:", e)
     }
   }
+}
+
+// Resolve a collective event type's co-host user IDs to their email addresses,
+// dropping any that don't have one on record. Returns [] for non-collective
+// event types or when the member list is empty — safe to call unconditionally.
+async function getCollectiveCoHostEmails(
+  eventType: EventType & { user: User }
+): Promise<string[]> {
+  if (!eventType.isCollective || eventType.collectiveMembers.length === 0) {
+    return []
+  }
+  const coHosts = await prisma.user.findMany({
+    where: { id: { in: eventType.collectiveMembers } },
+    select: { email: true },
+  })
+  return coHosts.map((u) => u.email).filter((e): e is string => Boolean(e))
 }
 
 async function fanoutWebhooks(userId: string, bookingId: string) {

--- a/src/lib/calendar/__tests__/google.test.ts
+++ b/src/lib/calendar/__tests__/google.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// ─── Mock googleapis ──────────────────────────────────────────────────────────
+//
+// We mock at the SDK boundary so we can assert exactly what payload reaches
+// calendar.events.insert. The reviewer flagged that without sendUpdates: "all"
+// Google silently skips attendee notification + external-calendar sync, which
+// would defeat the collective co-host invite path. This file pins the behavior.
+
+const mockEventsInsert = vi.fn()
+const mockEventsPatch = vi.fn()
+const mockFreebusyQuery = vi.fn()
+const mockCalendarFactory = vi.fn(() => ({
+  events: { insert: mockEventsInsert, patch: mockEventsPatch },
+  freebusy: { query: mockFreebusyQuery },
+}))
+
+vi.mock("googleapis", () => ({
+  google: {
+    calendar: (...args: any[]) => mockCalendarFactory(...args),
+    auth: {
+      // Inline class — vi.mock factories are hoisted above the file body, so
+      // declaring this at module scope would hit a TDZ error at import time.
+      OAuth2: class {
+        setCredentials() {}
+        on() {}
+      },
+    },
+  },
+}))
+
+// ─── Mock Prisma ──────────────────────────────────────────────────────────────
+
+const mockConnectionFindFirst = vi.fn()
+
+vi.mock("../../prisma", () => ({
+  default: {
+    calendarConnection: {
+      findFirst: (...args: any[]) => mockConnectionFindFirst(...args),
+      update: vi.fn(),
+    },
+  },
+}))
+
+// Import the SUT AFTER the mocks above so its module-level `import { google }`
+// resolves to our stub.
+import { createGoogleCalendarEvent } from "../google"
+
+describe("createGoogleCalendarEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConnectionFindFirst.mockResolvedValue({
+      id: "conn-1",
+      userId: "host-1",
+      provider: "GOOGLE",
+      accessToken: "at",
+      refreshToken: "rt",
+      isPrimary: true,
+    })
+    mockEventsInsert.mockResolvedValue({
+      data: { id: "evt-1", hangoutLink: "https://meet/x" },
+    })
+  })
+
+  it('passes sendUpdates: "all" so Google emails every attendee and syncs the event onto their calendars', async () => {
+    await createGoogleCalendarEvent("host-1", {
+      summary: "Collective sync",
+      startTime: new Date("2026-06-01T15:00:00Z"),
+      endTime: new Date("2026-06-01T15:30:00Z"),
+      attendees: [
+        { email: "alex@example.com" },
+        { email: "cohost1@example.com" },
+        { email: "cohost2@example.com" },
+      ],
+      conferenceData: true,
+    })
+
+    expect(mockEventsInsert).toHaveBeenCalledTimes(1)
+    expect(mockEventsInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarId: "primary",
+        sendUpdates: "all",
+        conferenceDataVersion: 1,
+        requestBody: expect.objectContaining({
+          attendees: [
+            { email: "alex@example.com" },
+            { email: "cohost1@example.com" },
+            { email: "cohost2@example.com" },
+          ],
+        }),
+      })
+    )
+  })
+
+  it("still includes sendUpdates: \"all\" when conferenceData is omitted", async () => {
+    await createGoogleCalendarEvent("host-1", {
+      summary: "Phone call",
+      startTime: new Date("2026-06-01T15:00:00Z"),
+      endTime: new Date("2026-06-01T15:30:00Z"),
+      attendees: [{ email: "alex@example.com" }],
+    })
+
+    expect(mockEventsInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ sendUpdates: "all", conferenceDataVersion: 0 })
+    )
+  })
+
+  it("returns null without calling insert when the host has no Google connection", async () => {
+    mockConnectionFindFirst.mockResolvedValueOnce(null)
+    const result = await createGoogleCalendarEvent("host-1", {
+      summary: "x",
+      startTime: new Date(),
+      endTime: new Date(),
+      attendees: [],
+    })
+    expect(result).toBeNull()
+    expect(mockEventsInsert).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/calendar/google.ts
+++ b/src/lib/calendar/google.ts
@@ -86,6 +86,12 @@ export async function createGoogleCalendarEvent(
     const res = await calendar.events.insert({
       calendarId: "primary",
       conferenceDataVersion: event.conferenceData ? 1 : 0,
+      // Without sendUpdates: "all", Google's default is "none" — so attendees
+      // (the booker and, for collective event types, every co-host) never
+      // receive an invite email and the event may not sync to their primary
+      // calendars. events.patch already uses "all" for reschedules; mirror
+      // that here so create + update both notify everyone.
+      sendUpdates: "all",
       requestBody: {
         summary: event.summary,
         description: event.description,


### PR DESCRIPTION
## Symptom

Collective conflict scanning correctly fans out across all hosts, but on booking creation **only the primary host gets the meeting**. Co-hosts listed in `EventType.collectiveMembers` receive no Google invite, the meeting never lands on their primary calendar, and they get no host email — so "collective" meetings effectively only work for the owner.

There's also a latent **double-booking hole** falling out of the same defect: the new `Booking` row is written with `userId = owner`, and nothing reaches the co-host's calendar either, so a subsequent conflict scan against that co-host sees nothing and can re-book the slot.

## Root cause

In `src/lib/bookings/create.ts`:

- `generateMeeting` (`GOOGLE_MEET` branch) called `createGoogleCalendarEvent(eventType.userId, …)` with `attendees: [{ email: bookerEmail }]` — owner-only event, booker-only attendee.
- `maybeCreateOutlookEvent` only writes to `eventType.userId`.
- `sendConfirmationEmails` only emails `eventType.user.email`.

None of those iterated `[owner, ...collectiveMembers]` the way `hasBookingConflict` (`src/lib/bookings/conflict-check.ts:26-30`) already does.

## Fix (Google-only, per scope)

- **`generateMeeting`**: resolve `collectiveMembers` user IDs to emails via `prisma.user.findMany` and append them to the `attendees` list on the owner's Google event. Google then sends invites, surfaces the Meet link, and (once a co-host accepts) drops the event onto their primary calendar — which is what `getConflictingEvents` reads for future collective conflict scans. This single change therefore also closes the double-booking gap.
- **`sendConfirmationEmails`**: fan out the "new booking" mail to `[owner, ...coHosts]`, deduped, so every host gets a TinyCal-styled confirmation with reschedule/cancel links regardless of whether Google's own attendee invite reached them.
- **New private helper `getCollectiveCoHostEmails`** short-circuits to `[]` for non-collective event types so both call sites stay unconditional and solo bookings don't take an extra Prisma query.

## Out of scope (deferred)

- **Outlook fanout** for co-hosts — out of scope per "Google only for now." A co-host on an Outlook mailbox still gets an iCal attachment via Google's attendee invite; native Outlook integration would need a per-host `BookingHost` table and a fanout loop next to `generateMeeting`.
- **Cancel & reschedule mirror work** — co-hosts are now Google attendees on the owner's event, so Google handles their notifications automatically when the owner's event is updated or deleted. Worth a follow-up to verify the TD-0047 sync cron treats updates the same way.

## Tests

- 6 new cases in `src/lib/bookings/__tests__/create.test.ts`:
  - co-hosts included as Google attendees
  - `prisma.user.findMany` queried with the right `collectiveMembers` ids
  - co-hosts with `email: null` dropped from attendees
  - host email goes to owner + every co-host
  - recipient list deduped when a co-host overlaps the owner
  - solo event types neither query users nor pad attendees
- `npx vitest run` — **291/291 pass** across 23 files.
- `npx tsc --noEmit` — no new errors in modified files. (Pre-existing errors in `stripe/*`, `auth.ts`, `ui/skeleton`, `lib/stripe.ts` are unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)