### PR TITLE
Show active availability resolution

### DIFF
--- a/src/app/api/availability/resolution/route.ts
+++ b/src/app/api/availability/resolution/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+import { getAuthenticatedUser } from "@/lib/auth"
+import { getAvailabilityResolutionSummary } from "@/lib/availability"
+
+// Dashboard-only: tells the UI which source (event-type schedule, user-default
+// schedule, or legacy Availability) actually wins for each event type, so the
+// editor can explain *why* a legacy rule change isn't moving slots. See #75.
+export async function GET() {
+  const user = await getAuthenticatedUser()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const summary = await getAvailabilityResolutionSummary(user.id)
+  return NextResponse.json(summary)
+}

--- a/src/app/dashboard/availability/page.tsx
+++ b/src/app/dashboard/availability/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { Save } from "lucide-react"
+import { AlertTriangle, Save } from "lucide-react"
+import Link from "next/link"
 
 const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
@@ -12,8 +13,24 @@ interface Rule {
   enabled: boolean
 }
 
+interface ResolutionEventType {
+  id: string
+  title: string
+  slug: string
+  source: "EVENT_TYPE_SCHEDULE" | "USER_DEFAULT_SCHEDULE" | "LEGACY_AVAILABILITY" | "NONE"
+  scheduleId: string | null
+  scheduleName: string | null
+}
+
+interface ResolutionSummary {
+  defaultSchedule: { id: string; name: string; ruleCount: number } | null
+  legacyRuleCount: number
+  eventTypes: ResolutionEventType[]
+}
+
 export default function AvailabilityPage() {
   const [rules, setRules] = useState<Rule[]>([])
+  const [resolution, setResolution] = useState<ResolutionSummary | null>(null)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
 
@@ -36,6 +53,10 @@ export default function AvailabilityPage() {
         setRules(byDay)
       }
     })
+    fetch("/api/availability/resolution")
+      .then(r => r.ok ? r.json() : null)
+      .then(setResolution)
+      .catch(() => setResolution(null))
   }, [])
 
   async function handleSave() {
@@ -50,6 +71,19 @@ export default function AvailabilityPage() {
     setTimeout(() => setSaved(false), 2000)
   }
 
+  const eventTypeCount = resolution?.eventTypes.length ?? 0
+  const usingLegacy = (resolution?.eventTypes ?? []).filter(
+    e => e.source === "LEGACY_AVAILABILITY"
+  ).length
+  const shadowedByDefault = (resolution?.eventTypes ?? []).filter(
+    e => e.source === "USER_DEFAULT_SCHEDULE"
+  ).length
+  const shadowedByEventSchedule = (resolution?.eventTypes ?? []).filter(
+    e => e.source === "EVENT_TYPE_SCHEDULE"
+  ).length
+  const shadowedCount = shadowedByDefault + shadowedByEventSchedule
+  const legacyIsFullyShadowed = eventTypeCount > 0 && usingLegacy === 0
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
@@ -59,6 +93,33 @@ export default function AvailabilityPage() {
           <Save className="w-4 h-4" /> {saving ? "Saving..." : saved ? "Saved ✓" : "Save"}
         </button>
       </div>
+
+      {resolution && shadowedCount > 0 && (
+        <div className={`mb-4 flex items-start gap-2 text-sm border rounded-lg px-4 py-3 ${
+          legacyIsFullyShadowed
+            ? "text-amber-800 bg-amber-50 border-amber-200"
+            : "text-blue-800 bg-blue-50 border-blue-200"
+        }`}>
+          <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+          <div>
+            {legacyIsFullyShadowed ? (
+              <>
+                These legacy rules <strong>aren&apos;t being used</strong> right now —
+                every event type resolves availability from a{" "}
+                <Link href="/dashboard/schedules" className="underline">schedule</Link>{" "}
+                instead{resolution.defaultSchedule ? <> (default: “{resolution.defaultSchedule.name}”)</> : null}.
+                Editing these rows won&apos;t change your bookable slots.
+              </>
+            ) : (
+              <>
+                {shadowedCount} of {eventTypeCount} event types resolve availability from a{" "}
+                <Link href="/dashboard/schedules" className="underline">schedule</Link>{" "}
+                instead of these legacy rules. The remaining {usingLegacy} still use the rules below.
+              </>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="bg-white border rounded-xl divide-y">
         {rules.map((rule, i) => (

--- a/src/app/dashboard/event-types/[id]/page.tsx
+++ b/src/app/dashboard/event-types/[id]/page.tsx
@@ -17,6 +17,21 @@ interface Schedule {
   isDefault: boolean
 }
 
+interface ResolutionEventType {
+  id: string
+  title: string
+  slug: string
+  source: "EVENT_TYPE_SCHEDULE" | "USER_DEFAULT_SCHEDULE" | "LEGACY_AVAILABILITY" | "NONE"
+  scheduleId: string | null
+  scheduleName: string | null
+}
+
+interface ResolutionSummary {
+  defaultSchedule: { id: string; name: string; ruleCount: number } | null
+  legacyRuleCount: number
+  eventTypes: ResolutionEventType[]
+}
+
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 function validateSlug(s: string): string | null {
@@ -35,6 +50,7 @@ export default function EditEventTypePage() {
   const [originalSlug, setOriginalSlug] = useState<string>("")
   const [userSlug, setUserSlug] = useState<string>("")
   const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [resolution, setResolution] = useState<ResolutionSummary | null>(null)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
 
@@ -49,6 +65,10 @@ export default function EditEventTypePage() {
     })
     fetch("/api/user").then(r => r.json()).then(u => setUserSlug(u?.slug ?? ""))
     fetch("/api/availability/schedules").then(r => r.json()).then(setSchedules)
+    fetch("/api/availability/resolution")
+      .then(r => r.ok ? r.json() : null)
+      .then(setResolution)
+      .catch(() => setResolution(null))
   }, [params.id])
 
   const slugError = et?.slug != null ? validateSlug(et.slug) : null
@@ -244,6 +264,11 @@ export default function EditEventTypePage() {
           <p className="text-xs text-gray-500 mt-1">
             Event type schedules override user defaults.
           </p>
+          <EffectiveSourceNote
+            eventTypeId={params.id as string}
+            resolution={resolution}
+            pendingScheduleId={et.availabilityScheduleId ?? null}
+          />
         </div>
 
         <h3 className="font-semibold mt-4">Scheduling Rules</h3>
@@ -393,6 +418,76 @@ export default function EditEventTypePage() {
           </div>
         )}
       </fieldset>
+    </div>
+  )
+}
+
+// Reflects the cascade in resolveAvailabilityRules so the editor can name the
+// actual winning source. Falls back to the saved-state summary when the user
+// hasn't touched the dropdown — otherwise we'd lie about a value they can't
+// see locally (rule counts for schedules).
+function EffectiveSourceNote({
+  eventTypeId,
+  resolution,
+  pendingScheduleId,
+}: {
+  eventTypeId: string
+  resolution: ResolutionSummary | null
+  pendingScheduleId: string | null
+}) {
+  if (!resolution) return null
+
+  const saved = resolution.eventTypes.find(e => e.id === eventTypeId)
+  // No saved entry yet (brand-new event type) — fall back to defaults-only logic.
+  const savedScheduleId = saved?.scheduleId ?? null
+
+  // If the user's pending pick matches what we already resolved, trust it.
+  // Otherwise re-derive *as if* only the schedule pointer changed, using the
+  // counts we know server-side.
+  let source: ResolutionEventType["source"]
+  let scheduleName: string | null = null
+
+  if (saved && pendingScheduleId === savedScheduleId) {
+    source = saved.source
+    scheduleName = saved.scheduleName
+  } else if (pendingScheduleId) {
+    // We don't know the picked schedule's rule count client-side — assume the
+    // selection wins and hint that saving will confirm.
+    source = "EVENT_TYPE_SCHEDULE"
+  } else if (resolution.defaultSchedule && resolution.defaultSchedule.ruleCount > 0) {
+    source = "USER_DEFAULT_SCHEDULE"
+    scheduleName = resolution.defaultSchedule.name
+  } else if (resolution.legacyRuleCount > 0) {
+    source = "LEGACY_AVAILABILITY"
+  } else {
+    source = "NONE"
+  }
+
+  const pendingDiffers = saved != null && pendingScheduleId !== savedScheduleId
+  const label =
+    source === "EVENT_TYPE_SCHEDULE"
+      ? `Currently using this event type's linked schedule${scheduleName ? ` (“${scheduleName}”)` : ""}.`
+      : source === "USER_DEFAULT_SCHEDULE"
+      ? `Currently using your default schedule${scheduleName ? ` (“${scheduleName}”)` : ""} — legacy availability rows are being shadowed.`
+      : source === "LEGACY_AVAILABILITY"
+      ? `Currently using your legacy Availability rules (no schedule is linked or has rules).`
+      : `No availability source resolves — bookings won't have any slots until you add rules.`
+
+  const tone =
+    source === "NONE"
+      ? "text-amber-700 bg-amber-50 border-amber-200"
+      : source === "LEGACY_AVAILABILITY"
+      ? "text-blue-800 bg-blue-50 border-blue-200"
+      : "text-gray-700 bg-gray-50 border-gray-200"
+
+  return (
+    <div className={`mt-2 text-xs border rounded px-3 py-2 ${tone}`}>
+      <div>{label}</div>
+      {pendingDiffers && (
+        <div className="mt-1 text-gray-600">
+          You changed the selection — save to apply.
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/dashboard/schedules/page.tsx
+++ b/src/app/dashboard/schedules/page.tsx
@@ -21,6 +21,21 @@ interface Schedule {
   rules: Rule[]
 }
 
+interface ResolutionEventType {
+  id: string
+  title: string
+  slug: string
+  source: "EVENT_TYPE_SCHEDULE" | "USER_DEFAULT_SCHEDULE" | "LEGACY_AVAILABILITY" | "NONE"
+  scheduleId: string | null
+  scheduleName: string | null
+}
+
+interface ResolutionSummary {
+  defaultSchedule: { id: string; name: string; ruleCount: number } | null
+  legacyRuleCount: number
+  eventTypes: ResolutionEventType[]
+}
+
 function defaultRule(): Rule {
   return { dayOfWeek: 1, startTime: "09:00", endTime: "17:00", enabled: true }
 }
@@ -88,6 +103,7 @@ function RulesEditor({
 
 export default function SchedulesPage() {
   const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [resolution, setResolution] = useState<ResolutionSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [creating, setCreating] = useState(false)
   const [newSchedule, setNewSchedule] = useState<{ name: string; rules: Rule[] }>({
@@ -106,9 +122,14 @@ export default function SchedulesPage() {
 
   async function fetchSchedules() {
     setLoading(true)
-    const res = await fetch("/api/availability/schedules")
-    const data = await res.json()
+    const [schedRes, resolutionRes] = await Promise.all([
+      fetch("/api/availability/schedules"),
+      fetch("/api/availability/resolution"),
+    ])
+    const data = await schedRes.json()
+    const resolution = resolutionRes.ok ? await resolutionRes.json().catch(() => null) : null
     setSchedules(data || [])
+    setResolution(resolution)
     setLoading(false)
   }
 
@@ -195,6 +216,23 @@ export default function SchedulesPage() {
     return <div className="text-center py-12">Loading schedules...</div>
   }
 
+  const usageByScheduleId = new Map<string, number>()
+  let defaultCascadeCount = 0
+  let legacyCascadeCount = 0
+  let noneCount = 0
+  for (const et of resolution?.eventTypes ?? []) {
+    if (et.source === "EVENT_TYPE_SCHEDULE" && et.scheduleId) {
+      usageByScheduleId.set(et.scheduleId, (usageByScheduleId.get(et.scheduleId) ?? 0) + 1)
+    } else if (et.source === "USER_DEFAULT_SCHEDULE") {
+      defaultCascadeCount++
+    } else if (et.source === "LEGACY_AVAILABILITY") {
+      legacyCascadeCount++
+    } else {
+      noneCount++
+    }
+  }
+  const eventTypeCount = resolution?.eventTypes.length ?? 0
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
@@ -206,6 +244,34 @@ export default function SchedulesPage() {
           <Plus className="w-4 h-4" /> New Schedule
         </button>
       </div>
+
+      {resolution && eventTypeCount > 0 && (
+        <div className="mb-6 bg-white border rounded-xl p-4 text-sm text-gray-700">
+          <div className="font-medium text-gray-900 mb-1">Where event types resolve availability today</div>
+          <ul className="space-y-0.5 text-gray-600">
+            {defaultCascadeCount > 0 && (
+              <li>
+                {defaultCascadeCount} of {eventTypeCount} use your default schedule
+                {resolution.defaultSchedule ? <> (“{resolution.defaultSchedule.name}”)</> : null}.
+              </li>
+            )}
+            {legacyCascadeCount > 0 && (
+              <li>
+                {legacyCascadeCount} of {eventTypeCount} still fall back to legacy Availability
+                {resolution.legacyRuleCount > 0 ? <> ({resolution.legacyRuleCount} legacy row{resolution.legacyRuleCount === 1 ? "" : "s"})</> : null}.
+              </li>
+            )}
+            {noneCount > 0 && (
+              <li className="text-amber-700">
+                {noneCount} of {eventTypeCount} have no resolvable availability — bookings will show no slots.
+              </li>
+            )}
+            {defaultCascadeCount === 0 && legacyCascadeCount === 0 && noneCount === 0 && (
+              <li>All event types are bound to a specific schedule.</li>
+            )}
+          </ul>
+        </div>
+      )}
 
       {creating && (
         <div className="bg-white border rounded-xl p-6 mb-6">
@@ -258,13 +324,35 @@ export default function SchedulesPage() {
           schedules.map(schedule => (
             <div key={schedule.id} className="bg-white border rounded-xl p-6">
               <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-3 flex-wrap">
                   <h3 className="text-lg font-semibold">{schedule.name}</h3>
                   {schedule.isDefault && (
                     <span className="bg-yellow-100 text-yellow-800 text-xs font-semibold px-2 py-1 rounded flex items-center gap-1">
                       <Star className="w-3 h-3" /> Default
                     </span>
                   )}
+                  {resolution && (() => {
+                    const linked = usageByScheduleId.get(schedule.id) ?? 0
+                    const fellThrough = schedule.isDefault ? defaultCascadeCount : 0
+                    const total = linked + fellThrough
+                    if (total === 0) {
+                      return (
+                        <span className="bg-gray-100 text-gray-600 text-xs px-2 py-1 rounded">
+                          No event types resolving here
+                        </span>
+                      )
+                    }
+                    return (
+                      <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded">
+                        {total} event type{total === 1 ? "" : "s"} resolve here
+                        {fellThrough > 0 && linked > 0
+                          ? ` (${linked} linked, ${fellThrough} via default)`
+                          : fellThrough > 0
+                          ? " (via default)"
+                          : ""}
+                      </span>
+                    )
+                  })()}
                 </div>
                 <div className="flex gap-2">
                   {editingId !== schedule.id && (

--- a/src/lib/__tests__/availability-resolution.test.ts
+++ b/src/lib/__tests__/availability-resolution.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  describeAvailabilitySource,
+  getAvailabilityResolutionSummary,
+} from "@/lib/availability"
+
+// ─── Mock Prisma ───
+
+const mockUserFindUnique = vi.fn()
+const mockAvailabilityScheduleFindUnique = vi.fn()
+const mockAvailabilityScheduleFindMany = vi.fn()
+const mockAvailabilityRuleCount = vi.fn()
+const mockAvailabilityCount = vi.fn()
+const mockEventTypeFindMany = vi.fn()
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+    },
+    availabilitySchedule: {
+      findUnique: (...args: unknown[]) => mockAvailabilityScheduleFindUnique(...args),
+      findMany: (...args: unknown[]) => mockAvailabilityScheduleFindMany(...args),
+    },
+    availabilityRule: {
+      count: (...args: unknown[]) => mockAvailabilityRuleCount(...args),
+      findMany: vi.fn(),
+    },
+    availability: {
+      count: (...args: unknown[]) => mockAvailabilityCount(...args),
+      findMany: vi.fn(),
+    },
+    eventType: {
+      findMany: (...args: unknown[]) => mockEventTypeFindMany(...args),
+    },
+  },
+}))
+
+const USER_ID = "user-1"
+const EVENT_SCHEDULE_ID = "sched-event"
+const DEFAULT_SCHEDULE_ID = "sched-default"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("describeAvailabilitySource", () => {
+  it("reports the event-type schedule when it has enabled rules", async () => {
+    mockAvailabilityScheduleFindUnique.mockResolvedValueOnce({
+      id: EVENT_SCHEDULE_ID,
+      name: "Sales Hours",
+    })
+    mockAvailabilityRuleCount.mockResolvedValueOnce(3)
+
+    const info = await describeAvailabilitySource(USER_ID, {
+      availabilityScheduleId: EVENT_SCHEDULE_ID,
+    })
+
+    expect(info).toEqual({
+      source: "EVENT_TYPE_SCHEDULE",
+      scheduleId: EVENT_SCHEDULE_ID,
+      scheduleName: "Sales Hours",
+      ruleCount: 3,
+    })
+    // Should short-circuit before checking user/legacy.
+    expect(mockUserFindUnique).not.toHaveBeenCalled()
+    expect(mockAvailabilityCount).not.toHaveBeenCalled()
+  })
+
+  it("falls through event-type schedule when no enabled rules exist on it", async () => {
+    // Event schedule lookup returns rows but ruleCount is 0
+    mockAvailabilityScheduleFindUnique
+      .mockResolvedValueOnce({ id: EVENT_SCHEDULE_ID, name: "Empty" }) // event schedule
+      .mockResolvedValueOnce({ id: DEFAULT_SCHEDULE_ID, name: "My Default" }) // default
+    mockAvailabilityRuleCount
+      .mockResolvedValueOnce(0) // event schedule has no enabled rules
+      .mockResolvedValueOnce(5) // default schedule does
+
+    mockUserFindUnique.mockResolvedValueOnce({
+      defaultAvailabilityScheduleId: DEFAULT_SCHEDULE_ID,
+    })
+
+    const info = await describeAvailabilitySource(USER_ID, {
+      availabilityScheduleId: EVENT_SCHEDULE_ID,
+    })
+
+    expect(info).toEqual({
+      source: "USER_DEFAULT_SCHEDULE",
+      scheduleId: DEFAULT_SCHEDULE_ID,
+      scheduleName: "My Default",
+      ruleCount: 5,
+    })
+  })
+
+  it("reports legacy availability when no schedules win the cascade", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({
+      defaultAvailabilityScheduleId: null,
+    })
+    mockAvailabilityCount.mockResolvedValueOnce(7)
+
+    const info = await describeAvailabilitySource(USER_ID, {
+      availabilityScheduleId: null,
+    })
+
+    expect(info).toEqual({
+      source: "LEGACY_AVAILABILITY",
+      scheduleId: null,
+      scheduleName: null,
+      ruleCount: 7,
+    })
+  })
+
+  it("reports NONE when nothing is configured", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({
+      defaultAvailabilityScheduleId: null,
+    })
+    mockAvailabilityCount.mockResolvedValueOnce(0)
+
+    const info = await describeAvailabilitySource(USER_ID, {
+      availabilityScheduleId: null,
+    })
+
+    expect(info.source).toBe("NONE")
+    expect(info.ruleCount).toBe(0)
+  })
+})
+
+describe("getAvailabilityResolutionSummary", () => {
+  it("classifies each event type by its winning source", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({
+      defaultAvailabilityScheduleId: DEFAULT_SCHEDULE_ID,
+      defaultAvailabilitySchedule: { id: DEFAULT_SCHEDULE_ID, name: "My Default" },
+    })
+    mockEventTypeFindMany.mockResolvedValueOnce([
+      { id: "et-linked", title: "Linked", slug: "linked", availabilityScheduleId: EVENT_SCHEDULE_ID },
+      { id: "et-default", title: "Falls to default", slug: "fd", availabilityScheduleId: null },
+    ])
+    mockAvailabilityCount.mockResolvedValueOnce(2) // legacy rows present but shadowed by default
+    mockAvailabilityRuleCount.mockResolvedValueOnce(5) // default schedule rule count
+    mockAvailabilityScheduleFindMany.mockResolvedValueOnce([
+      { id: EVENT_SCHEDULE_ID, name: "Sales Hours", _count: { rules: 3 } },
+    ])
+
+    const summary = await getAvailabilityResolutionSummary(USER_ID)
+
+    expect(summary.defaultSchedule).toEqual({
+      id: DEFAULT_SCHEDULE_ID,
+      name: "My Default",
+      ruleCount: 5,
+    })
+    expect(summary.legacyRuleCount).toBe(2)
+    expect(summary.eventTypes).toEqual([
+      {
+        id: "et-linked",
+        title: "Linked",
+        slug: "linked",
+        source: "EVENT_TYPE_SCHEDULE",
+        scheduleId: EVENT_SCHEDULE_ID,
+        scheduleName: "Sales Hours",
+      },
+      {
+        id: "et-default",
+        title: "Falls to default",
+        slug: "fd",
+        source: "USER_DEFAULT_SCHEDULE",
+        scheduleId: DEFAULT_SCHEDULE_ID,
+        scheduleName: "My Default",
+      },
+    ])
+  })
+
+  it("falls a linked event type through to default when its schedule has no enabled rules", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({
+      defaultAvailabilityScheduleId: DEFAULT_SCHEDULE_ID,
+      defaultAvailabilitySchedule: { id: DEFAULT_SCHEDULE_ID, name: "Default" },
+    })
+    mockEventTypeFindMany.mockResolvedValueOnce([
+      { id: "et-linked", title: "Linked", slug: "linked", availabilityScheduleId: EVENT_SCHEDULE_ID },
+    ])
+    mockAvailabilityCount.mockResolvedValueOnce(0)
+    mockAvailabilityRuleCount.mockResolvedValueOnce(4)
+    mockAvailabilityScheduleFindMany.mockResolvedValueOnce([
+      { id: EVENT_SCHEDULE_ID, name: "Empty", _count: { rules: 0 } },
+    ])
+
+    const summary = await getAvailabilityResolutionSummary(USER_ID)
+
+    expect(summary.eventTypes[0].source).toBe("USER_DEFAULT_SCHEDULE")
+    expect(summary.eventTypes[0].scheduleName).toBe("Default")
+  })
+
+  it("falls through to legacy when neither schedule layer has rules", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({
+      defaultAvailabilityScheduleId: null,
+      defaultAvailabilitySchedule: null,
+    })
+    mockEventTypeFindMany.mockResolvedValueOnce([
+      { id: "et-1", title: "Discovery", slug: "discovery", availabilityScheduleId: null },
+    ])
+    mockAvailabilityCount.mockResolvedValueOnce(3)
+
+    const summary = await getAvailabilityResolutionSummary(USER_ID)
+
+    expect(summary.defaultSchedule).toBeNull()
+    expect(summary.legacyRuleCount).toBe(3)
+    expect(summary.eventTypes[0].source).toBe("LEGACY_AVAILABILITY")
+  })
+
+  it("marks event types as NONE when nothing resolves", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({
+      defaultAvailabilityScheduleId: null,
+      defaultAvailabilitySchedule: null,
+    })
+    mockEventTypeFindMany.mockResolvedValueOnce([
+      { id: "et-1", title: "Discovery", slug: "discovery", availabilityScheduleId: null },
+    ])
+    mockAvailabilityCount.mockResolvedValueOnce(0)
+
+    const summary = await getAvailabilityResolutionSummary(USER_ID)
+
+    expect(summary.eventTypes[0].source).toBe("NONE")
+  })
+})

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -52,6 +52,211 @@ export async function resolveAvailabilityRules(
   return prisma.availability.findMany({ where: { userId, enabled: true } })
 }
 
+// ─── Resolution reporting ───
+//
+// resolveAvailabilityRules silently cascades event-type schedule → user-default
+// schedule → legacy Availability rows. That's fine for booking math, but the
+// dashboard needs to tell users *which* source is winning — otherwise editing
+// legacy rows that are being shadowed by a schedule looks like a no-op.
+// (See issue #75.)
+
+export type AvailabilitySource =
+  | "EVENT_TYPE_SCHEDULE"
+  | "USER_DEFAULT_SCHEDULE"
+  | "LEGACY_AVAILABILITY"
+  | "NONE"
+
+export interface AvailabilitySourceInfo {
+  source: AvailabilitySource
+  scheduleId: string | null
+  scheduleName: string | null
+  ruleCount: number
+}
+
+export async function describeAvailabilitySource(
+  userId: string,
+  eventType: { availabilityScheduleId: string | null }
+): Promise<AvailabilitySourceInfo> {
+  if (eventType.availabilityScheduleId) {
+    const [schedule, ruleCount] = await Promise.all([
+      prisma.availabilitySchedule.findUnique({
+        where: { id: eventType.availabilityScheduleId },
+        select: { id: true, name: true },
+      }),
+      prisma.availabilityRule.count({
+        where: { availabilityScheduleId: eventType.availabilityScheduleId, enabled: true },
+      }),
+    ])
+    if (schedule && ruleCount > 0) {
+      return {
+        source: "EVENT_TYPE_SCHEDULE",
+        scheduleId: schedule.id,
+        scheduleName: schedule.name,
+        ruleCount,
+      }
+    }
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { defaultAvailabilityScheduleId: true },
+  })
+  if (user?.defaultAvailabilityScheduleId) {
+    const [schedule, ruleCount] = await Promise.all([
+      prisma.availabilitySchedule.findUnique({
+        where: { id: user.defaultAvailabilityScheduleId },
+        select: { id: true, name: true },
+      }),
+      prisma.availabilityRule.count({
+        where: { availabilityScheduleId: user.defaultAvailabilityScheduleId, enabled: true },
+      }),
+    ])
+    if (schedule && ruleCount > 0) {
+      return {
+        source: "USER_DEFAULT_SCHEDULE",
+        scheduleId: schedule.id,
+        scheduleName: schedule.name,
+        ruleCount,
+      }
+    }
+  }
+
+  const legacyCount = await prisma.availability.count({
+    where: { userId, enabled: true },
+  })
+  if (legacyCount > 0) {
+    return {
+      source: "LEGACY_AVAILABILITY",
+      scheduleId: null,
+      scheduleName: null,
+      ruleCount: legacyCount,
+    }
+  }
+
+  return { source: "NONE", scheduleId: null, scheduleName: null, ruleCount: 0 }
+}
+
+export interface AvailabilityResolutionSummary {
+  defaultSchedule: { id: string; name: string; ruleCount: number } | null
+  legacyRuleCount: number
+  eventTypes: Array<{
+    id: string
+    title: string
+    slug: string
+    source: AvailabilitySource
+    scheduleId: string | null
+    scheduleName: string | null
+  }>
+}
+
+export async function getAvailabilityResolutionSummary(
+  userId: string
+): Promise<AvailabilityResolutionSummary> {
+  const [user, eventTypes, legacyRuleCount] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        defaultAvailabilityScheduleId: true,
+        defaultAvailabilitySchedule: {
+          select: { id: true, name: true },
+        },
+      },
+    }),
+    prisma.eventType.findMany({
+      where: { userId },
+      select: { id: true, title: true, slug: true, availabilityScheduleId: true },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.availability.count({ where: { userId, enabled: true } }),
+  ])
+
+  let defaultSchedule: AvailabilityResolutionSummary["defaultSchedule"] = null
+  if (user?.defaultAvailabilitySchedule) {
+    const ruleCount = await prisma.availabilityRule.count({
+      where: {
+        availabilityScheduleId: user.defaultAvailabilitySchedule.id,
+        enabled: true,
+      },
+    })
+    defaultSchedule = {
+      id: user.defaultAvailabilitySchedule.id,
+      name: user.defaultAvailabilitySchedule.name,
+      ruleCount,
+    }
+  }
+
+  // Pre-fetch enabled-rule counts for every linked event-type schedule so we
+  // avoid an N+1 in describeAvailabilitySource when summarising.
+  const linkedScheduleIds = Array.from(
+    new Set(
+      eventTypes
+        .map((et) => et.availabilityScheduleId)
+        .filter((id): id is string => !!id)
+    )
+  )
+  const linkedSchedules = linkedScheduleIds.length
+    ? await prisma.availabilitySchedule.findMany({
+        where: { id: { in: linkedScheduleIds } },
+        select: {
+          id: true,
+          name: true,
+          _count: { select: { rules: { where: { enabled: true } } } },
+        },
+      })
+    : []
+  const linkedById = new Map(linkedSchedules.map((s) => [s.id, s]))
+
+  const eventTypeSummaries = eventTypes.map((et) => {
+    if (et.availabilityScheduleId) {
+      const linked = linkedById.get(et.availabilityScheduleId)
+      if (linked && linked._count.rules > 0) {
+        return {
+          id: et.id,
+          title: et.title,
+          slug: et.slug,
+          source: "EVENT_TYPE_SCHEDULE" as const,
+          scheduleId: linked.id,
+          scheduleName: linked.name,
+        }
+      }
+    }
+    if (defaultSchedule && defaultSchedule.ruleCount > 0) {
+      return {
+        id: et.id,
+        title: et.title,
+        slug: et.slug,
+        source: "USER_DEFAULT_SCHEDULE" as const,
+        scheduleId: defaultSchedule.id,
+        scheduleName: defaultSchedule.name,
+      }
+    }
+    if (legacyRuleCount > 0) {
+      return {
+        id: et.id,
+        title: et.title,
+        slug: et.slug,
+        source: "LEGACY_AVAILABILITY" as const,
+        scheduleId: null,
+        scheduleName: null,
+      }
+    }
+    return {
+      id: et.id,
+      title: et.title,
+      slug: et.slug,
+      source: "NONE" as const,
+      scheduleId: null,
+      scheduleName: null,
+    }
+  })
+
+  return {
+    defaultSchedule,
+    legacyRuleCount,
+    eventTypes: eventTypeSummaries,
+  }
+}
+
 export async function getAvailableSlots(options: AvailabilityOptions): Promise<TimeSlot[]> {
   const { userId, eventTypeId, startDate, endDate, timezone: _timezone } = options
 


### PR DESCRIPTION
## Summary
- Add a dashboard API summary that mirrors the availability cascade and reports the winning source per event type.
- Surface active availability resolution on schedules, event type edit, and legacy Availability dashboard pages.
- Add coverage for event-type schedule, default schedule, legacy Availability, and no-source fallback cases.

## Tests
- `npm test -- --run src/lib/__tests__/availability-resolution.test.ts`
- `npm run lint` *(fails on pre-existing `src/app/api/meeting-links/[uid]/confirm/route.ts:179` unused variable; no new lint errors from this change)*
- `npx prisma generate && npx tsc --noEmit --pretty false -p .` *(fails on pre-existing Stripe/auth/UI typing issues; no errors observed in changed files)*

Fixes zenithventure/tinycal#75
